### PR TITLE
Implicit dependency on RuboCop RSpec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Use latest RuboCop RSpec from `master`
         run: |
+          sed -e '/rubocop-rspec/d' -i Gemfile
           echo "gem 'rubocop-rspec', github: 'rubocop/rubocop-rspec'" > Gemfile.local
       - uses: ruby/setup-ruby@v1
         with:
@@ -102,7 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Use latest RSpec 4 from `4-0-dev` branch
         run: |
-          sed -e '/rspec/d' -i Gemfile
+          sed -e "/^gem 'rspec/d" -i Gemfile
           cat << EOF > Gemfile.local
             gem 'rspec', github: 'rspec/rspec-metagem', branch: '4-0-dev'
             gem 'rspec-core', github: 'rspec/rspec-core', branch: '4-0-dev'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Implicit dependency on RuboCop RSpec. Note that if you use rubocop-rspec_rails, you must also explicitly add rubocop-rspec to the Gemfile, because you are changing to an implicit dependency on RuboCop RSpec. ([@ydah])
+
 ## 2.28.0 (2024-03-28)
 
 - Extracted from `rubocop-rspec` into a separate repository. ([@ydah])

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,8 @@ gem 'rubocop-rake', '~> 0.6'
 gem 'simplecov', '>= 0.19'
 gem 'yard'
 
+# TODO: Move to gemspec when RuboCop RSpec v3 is released.
+gem 'rubocop-rspec', '~> 2.27'
+
 local_gemfile = 'Gemfile.local'
 eval_gemfile(local_gemfile) if File.exist?(local_gemfile)

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@
 
 ## Installation
 
-Just install the `rubocop-rspec_rails` gem
+**This gem implicitly depends on the `rubocop-rspec` gem, so you should install it first.**
+Just install the `rubocop-rspec` and `rubocop-rspec_rails` gem
 
 ```bash
-gem install rubocop-rspec_rails
+gem install rubocop-rspec rubocop-rspec_rails
 ```
 
 or if you use bundler put this in your `Gemfile`
 
 ```ruby
+gem 'rubocop-rspec', require: false
 gem 'rubocop-rspec_rails', require: false
 ```
 

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -1,15 +1,17 @@
 = Installation
 
-Just install the `rubocop-rspec_rails` gem
+*This gem implicitly depends on the `rubocop-rspec` gem, so you should install it first.*
+Just install the `rubocop-rspec` and `rubocop-rspec_rails` gem
 
 [source,bash]
 ----
-gem install rubocop-rspec_rails
+gem install rubocop-rspec rubocop-rspec_rails
 ----
 
 or if you use bundler put this in your `Gemfile`
 
 [source,ruby]
 ----
-gem 'rubocop-rspec_rails'
+gem 'rubocop-rspec', require: false
+gem 'rubocop-rspec_rails', require: false
 ----

--- a/rubocop-rspec_rails.gemspec
+++ b/rubocop-rspec_rails.gemspec
@@ -35,5 +35,4 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency 'rubocop', '~> 1.40'
-  spec.add_runtime_dependency 'rubocop-rspec', '~> 2.27'
 end


### PR DESCRIPTION
It is extracted from RuboCop RSpec, but needs to rely on rubocop-rspec_rails from RuboCop RSpec, and RuboCop RSpec Rails also needs to rely on rubocop-rspec. This makes them interdependent, and if you explicitly specify a dependency, you are stuck in an infinite loop.

```
❯ bundle install
Your bundle requires gems that depend on each other, creating an infinite loop. Please remove either gem 'rubocop-rspec' or gem 'rubocop-rspec_rails' and try again.
```

Therefore, this PR changes the dependency to be implicit. The next major version update of RuboCop RSpec will remove the dependency on rubocop-rspec_rails, so we will change the dependency to be explicit at that point.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
