### PR TITLE
Fix a `NameError` by Cross-Referencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a `NameError` by Cross-Referencing. ([@ydah])
+
 ## 2.28.1 (2024-03-29)
 
 - Implicit dependency on RuboCop RSpec. Note that if you use rubocop-rspec_rails, you must also explicitly add rubocop-rspec to the Gemfile, because you are changing to an implicit dependency on RuboCop RSpec. ([@ydah])

--- a/lib/rubocop-rspec_rails.rb
+++ b/lib/rubocop-rspec_rails.rb
@@ -4,10 +4,14 @@ require 'pathname'
 require 'yaml'
 
 require 'rubocop'
-require 'rubocop-rspec'
+
+require 'rubocop/rspec/language/node_pattern'
+
+require 'rubocop/rspec/language'
 
 require_relative 'rubocop/rspec_rails/version'
 
+require 'rubocop/cop/rspec/base'
 require_relative 'rubocop/cop/rspec_rails_cops'
 
 project_root = File.join(__dir__, '..')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,4 +50,5 @@ end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
+require 'rubocop-rspec'
 require 'rubocop-rspec_rails'


### PR DESCRIPTION
```
❯ bundle exec rspec

An error occurred while loading spec_helper.
Failure/Error: require 'rubocop-rspec'

NameError:
  uninitialized constant RuboCop::Cop::RSpecRails
# ./lib/rubocop-rspec_rails.rb:7:in `<top (required)>'
# ./spec/spec_helper.rb:53:in `<top (required)>'
No examples found.
No examples found.
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).