### PR TITLE
Fix an error for `RSpecRails/HttpStatus` when no rack gem is loaded with rubocop-rspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a `NameError` by Cross-Referencing. ([@ydah])
+- Fix an error for `RSpecRails/HttpStatus` when no rack gem is loaded with rubocop-rspec. ([@ydah])
 
 ## 2.28.1 (2024-03-29)
 

--- a/lib/rubocop/cop/rspec_rails/http_status.rb
+++ b/lib/rubocop/cop/rspec_rails/http_status.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require 'rack/utils'
+begin
+  require 'rack/utils'
+rescue LoadError
+  # RSpecRails/HttpStatus cannot be loaded if rack/utils is unavailable.
+end
 
 module RuboCop
   module Cop
@@ -64,6 +68,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return unless defined?(::Rack::Utils::SYMBOL_TO_STATUS_CODE)
+
           http_status(node) do |arg|
             return if arg.str_type? && arg.heredoc?
 

--- a/lib/rubocop/cop/rspec_rails_cops.rb
+++ b/lib/rubocop/cop/rspec_rails_cops.rb
@@ -2,12 +2,8 @@
 
 require_relative 'rspec_rails/avoid_setup_hook'
 require_relative 'rspec_rails/have_http_status'
-require_relative 'rspec_rails/negation_be_valid'
-begin
-  require_relative 'rspec_rails/http_status'
-rescue LoadError
-  # RSpecRails/HttpStatus cannot be loaded if rack/utils is unavailable.
-end
+require_relative 'rspec_rails/http_status'
 require_relative 'rspec_rails/inferred_spec_type'
 require_relative 'rspec_rails/minitest_assertions'
+require_relative 'rspec_rails/negation_be_valid'
 require_relative 'rspec_rails/travel_around'


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec_rails/issues/9

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
