### PR TITLE
Fix an error for unrecognized cop or department `RSpecRails/HttpStatus` when also using rubocop-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a `NameError` by Cross-Referencing. ([@ydah])
 - Fix an error for `RSpecRails/HttpStatus` when no rack gem is loaded with rubocop-rspec. ([@ydah])
+- Fix an error for unrecognized cop or department `RSpecRails/HttpStatus` when also using rubocop-rails. ([@ydah])
 
 ## 2.28.1 (2024-03-29)
 

--- a/lib/rubocop-rspec_rails.rb
+++ b/lib/rubocop-rspec_rails.rb
@@ -16,3 +16,20 @@ require_relative 'rubocop/cop/rspec_rails_cops'
 
 project_root = File.join(__dir__, '..')
 RuboCop::ConfigLoader.inject_defaults!(project_root)
+
+# FIXME: This is a workaround for the following issue:
+# https://github.com/rubocop/rubocop-rspec_rails/issues/8
+module RuboCop
+  module Cop
+    class AmbiguousCopName # rubocop:disable Style/Documentation
+      prepend(Module.new do
+        def qualified_cop_name(name, path, warn: true)
+          return super unless name == 'RSpec/Rails/HttpStatus'
+
+          badge = Badge.parse(name)
+          resolve_badge(badge, qualify_badge(badge).first, path)
+        end
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec_rails/issues/8

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).