### PR TITLE
Change superclass for many cops

### DIFF
--- a/lib/rubocop/cop/rspec_rails/avoid_setup_hook.rb
+++ b/lib/rubocop/cop/rspec_rails/avoid_setup_hook.rb
@@ -16,7 +16,7 @@ module RuboCop
       #     allow(foo).to receive(:bar)
       #   end
       #
-      class AvoidSetupHook < ::RuboCop::Cop::RSpec::Base
+      class AvoidSetupHook < ::RuboCop::Cop::Base
         extend AutoCorrector
 
         MSG = 'Use `before` instead of `setup`.'

--- a/lib/rubocop/cop/rspec_rails/http_status.rb
+++ b/lib/rubocop/cop/rspec_rails/http_status.rb
@@ -57,7 +57,7 @@ module RuboCop
       #   it { is_expected.to have_http_status :success }
       #   it { is_expected.to have_http_status :error }
       #
-      class HttpStatus < ::RuboCop::Cop::RSpec::Base
+      class HttpStatus < ::RuboCop::Cop::Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle
         RESTRICT_ON_SEND = %i[have_http_status].freeze

--- a/lib/rubocop/cop/rspec_rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec_rails/minitest_assertions.rb
@@ -29,7 +29,7 @@ module RuboCop
       #   expect(a).to be(true)
       #   expect(a).to be(false)
       #
-      class MinitestAssertions < ::RuboCop::Cop::RSpec::Base
+      class MinitestAssertions < ::RuboCop::Cop::Base
         extend AutoCorrector
 
         # :nodoc:

--- a/lib/rubocop/cop/rspec_rails/negation_be_valid.rb
+++ b/lib/rubocop/cop/rspec_rails/negation_be_valid.rb
@@ -29,7 +29,7 @@ module RuboCop
       #   # good (with method chain)
       #   expect(foo).to be_invalid.or be_even
       #
-      class NegationBeValid < ::RuboCop::Cop::RSpec::Base
+      class NegationBeValid < ::RuboCop::Cop::Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/rspec_rails/travel_around.rb
+++ b/lib/rubocop/cop/rspec_rails/travel_around.rb
@@ -23,7 +23,7 @@ module RuboCop
       #
       #   # good
       #   before { freeze_time }
-      class TravelAround < ::RuboCop::Cop::RSpec::Base
+      class TravelAround < ::RuboCop::Cop::Base
         extend AutoCorrector
 
         MSG = 'Prefer to travel in `before` rather than `around`.'


### PR DESCRIPTION
Let's depend as little as possible on `::RuboCop::Cop::RSpec::Base` as cop superclass.

Now, only `InferredSpecType` inherits from rubocop-rspec's base class.

See also https://github.com/rubocop/rubocop-rspec/pull/1511

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] ~Added tests.~
- [ ] ~Updated documentation.~
- [ ] ~Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
