### PR TITLE
Change superclass for InferredSpecType

### DIFF
--- a/lib/rubocop/rspec_rails/description_extractor.rb
+++ b/lib/rubocop/rspec_rails/description_extractor.rb
@@ -21,7 +21,6 @@ module RuboCop
 
       # Decorator of a YARD code object for working with documented rspec cops
       class CodeObject
-        RSPEC_RAILS_COP_CLASS_NAME = 'RuboCop::Cop::RSpec::Base'
         RUBOCOP_COP_CLASS_NAME = 'RuboCop::Cop::Base'
 
         def initialize(yardoc)
@@ -57,8 +56,7 @@ module RuboCop
         end
 
         def cop_subclass?
-          yardoc.superclass.path == RSPEC_RAILS_COP_CLASS_NAME ||
-            yardoc.superclass.path == RUBOCOP_COP_CLASS_NAME
+          yardoc.superclass.path == RUBOCOP_COP_CLASS_NAME
         end
 
         def abstract?


### PR DESCRIPTION
This copies some of the code from the `RuboCop::RSpec::Language` module in rubocop-rspec, and it no longer allows the user to configure aliases for example group methods (`describe`, `fcontext`, `xfeature` etc.).

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] ~Added tests.~
- [ ] ~Updated documentation.~
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
