### PR TITLE
Add specs for unsafe cops in default_config_spec.rb

### DIFF
--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe 'config/default.yml' do
     cop_names + namespaces.values
   end
 
+  let(:unsafe_cops) do
+    require 'yard'
+    YARD::Registry.load!
+    YARD::Registry.all(:class).select do |example|
+      example.tags.any? { |tag| tag.tag_name == 'safety' }
+    end
+  end
+
+  let(:unsafe_cop_names) do
+    unsafe_cops.map do |cop|
+      dept_and_cop_names =
+        cop.path.split('::')[2..] # Drop `RuboCop::Cop` from class name.
+      dept_and_cop_names.join('/')
+    end
+  end
+
   def cop_configuration(config_key)
     cop_names.map do |cop_name|
       cop_config = default_config[cop_name]
@@ -75,5 +91,32 @@ RSpec.describe 'config/default.yml' do
   it 'includes a valid Enabled for every cop' do
     expect(cop_configuration('Enabled'))
       .to all be(true).or(be(false)).or(eq('pending'))
+  end
+
+  it 'does not include unnecessary `SafeAutoCorrect: false`' do
+    cop_names.each do |cop_name|
+      next unless default_config.dig(cop_name, 'Safe') == false
+
+      safe_autocorrect = default_config.dig(cop_name, 'SafeAutoCorrect')
+
+      expect(safe_autocorrect).not_to(
+        be(false),
+        "`#{cop_name}` has unnecessary `SafeAutoCorrect: false` config."
+      )
+    end
+  end
+
+  it 'is expected that all cops documented with `@safety` are `Safe: false`' \
+     ' or `SafeAutoCorrect: false`' do
+    unsafe_cop_names.each do |cop_name|
+      unsafe = default_config[cop_name]['Safe'] == false ||
+        default_config[cop_name]['SafeAutoCorrect'] == false
+      expect(unsafe).to(
+        be(true),
+        "`#{cop_name}` cop should be set `Safe: false` or " \
+        '`SafeAutoCorrect: false` because `@safety` YARD tag exists.'
+      )
+      YARD::Registry.clear
+    end
   end
 end


### PR DESCRIPTION
Follow up:
- https://github.com/rubocop/rubocop-rspec/pull/1841
- https://github.com/rubocop/rubocop-rspec/pull/1842

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
