### PR TITLE
Fix an error for Ambiguous cop name `RSpec/Rails/HttpStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix an error for Ambiguous cop name `RSpec/Rails/HttpStatus`. ([@ydah])
+
 ## 2.28.2 (2024-03-31)
 
 - Fix a `NameError` by Cross-Referencing. ([@ydah])

--- a/lib/rubocop-rspec_rails.rb
+++ b/lib/rubocop-rspec_rails.rb
@@ -21,7 +21,7 @@ RuboCop::ConfigLoader.inject_defaults!(project_root)
 # https://github.com/rubocop/rubocop-rspec_rails/issues/8
 module RuboCop
   module Cop
-    class AmbiguousCopName # rubocop:disable Style/Documentation
+    class Registry # rubocop:disable Style/Documentation
       prepend(Module.new do
         def qualified_cop_name(name, path, warn: true)
           return super unless name == 'RSpec/Rails/HttpStatus'


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec_rails/issues/18
This PR fixes an error for Ambiguous cop name `RSpec/Rails/HttpStatus` in the `rubocop-rspec_rails` gem.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
