### PR TITLE
Don't require rubocop/rspec/language/node_pattern

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,15 +98,16 @@ RSpec/ExampleLength:
     - heredoc
   Max: 11
 
-RSpec/FilePath:
-  Enabled: false
-
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
 
 RSpec/MultipleExpectations:
   Max: 2
+
+RSpec/SpecFilePathFormat:
+  CustomTransform:
+    RSpecRails: rspec_rails
 
 Style/FormatStringToken:
   Exclude:
@@ -135,58 +136,5 @@ Style/ReturnNilInPredicateMethodDefinition:
   Enabled: true
 
 # Enable pending rubocop-rspec cops.
-
-RSpec/BeEmpty:
-  Enabled: true
-RSpec/BeEq:
-  Enabled: true
-RSpec/BeNil:
-  Enabled: true
-RSpec/ChangeByZero:
-  Enabled: true
-RSpec/ClassCheck:
-  Enabled: true
-RSpec/ContainExactly:
-  Enabled: true
-RSpec/DuplicatedMetadata:
-  Enabled: true
-RSpec/EmptyMetadata:
-  Enabled: true
-RSpec/Eq:
-  Enabled: true
-RSpec/ExcessiveDocstringSpacing:
-  Enabled: true
-RSpec/IdenticalEqualityAssertion:
-  Enabled: true
-RSpec/IndexedLet:
-  Enabled: true
-RSpec/IsExpectedSpecify:
-  Enabled: true
-RSpec/MatchArray:
-  Enabled: true
-RSpec/MetadataStyle:
-  Enabled: true
-RSpec/NoExpectationExample:
-  Enabled: true
-RSpec/PendingWithoutReason:
-  Enabled: true
-RSpec/ReceiveMessages:
-  Enabled: true
-RSpec/RedundantAround:
-  Enabled: true
-RSpec/RedundantPredicateMatcher:
-  Enabled: true
-RSpec/RemoveConst:
-  Enabled: true
-RSpec/RepeatedSubjectCall:
-  Enabled: true
-RSpec/SkipBlockInsideExample:
-  Enabled: true
-RSpec/SortMetadata:
-  Enabled: true
-RSpec/SpecFilePathSuffix:
-  Enabled: true
-RSpec/SubjectDeclaration:
-  Enabled: true
-RSpec/VerifiedDoubleReference:
-  Enabled: true
+#
+# No pending cops yet.

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,5 @@ gem 'rubocop-rake', '~> 0.6'
 gem 'simplecov', '>= 0.19'
 gem 'yard'
 
-# TODO: Move to gemspec when RuboCop RSpec v3 is released.
-gem 'rubocop-rspec', '~> 2.27'
-
 local_gemfile = 'Gemfile.local'
 eval_gemfile(local_gemfile) if File.exist?(local_gemfile)

--- a/lib/rubocop-rspec_rails.rb
+++ b/lib/rubocop-rspec_rails.rb
@@ -4,9 +4,6 @@ require 'pathname'
 require 'yaml'
 
 require 'rubocop'
-
-require 'rubocop/rspec/language/node_pattern'
-
 require 'rubocop/rspec/language'
 
 require_relative 'rubocop/rspec_rails/version'

--- a/rubocop-rspec_rails.gemspec
+++ b/rubocop-rspec_rails.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency 'rubocop', '~> 1.61'
+  spec.add_runtime_dependency 'rubocop-rspec', '~> 3', '>= 3.0.1'
 end


### PR DESCRIPTION
The node_pattern file has been removed from rubocop-rspec, and we should no longer require it.

Also, the `RSpec/FilePath` has been split and `RSpec/SpecFilePathFormat` can be configured to work instead.

Fixes #41.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
