### PR TITLE
Support `AutoCorrect: contextual` option for LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Support `AutoCorrect: contextual` option for LSP. ([@ydah])
+
 ## 2.28.3 (2024-04-11)
 
 - Fix an error for Ambiguous cop name `RSpec/Rails/HttpStatus`. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -66,6 +66,7 @@ RSpecRails/MinitestAssertions:
 
 RSpecRails/NegationBeValid:
   Description: Enforces use of `be_invalid` or `not_to` for negated be_valid.
+  AutoCorrect: contextual
   Safe: false
   EnforcedStyle: not_to
   SupportedStyles:
@@ -73,6 +74,7 @@ RSpecRails/NegationBeValid:
     - be_invalid
   Enabled: pending
   VersionAdded: '2.23'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/NegationBeValid
 
 RSpecRails/TravelAround:

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -321,9 +321,9 @@ expect(a).to be(false)
 
 | Pending
 | No
-| Always (Unsafe)
+| Command-line only (Unsafe)
 | 2.23
-| -
+| <<next>>
 |===
 
 Enforces use of `be_invalid` or `not_to` for negated be_valid.


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop-rspec/pull/1899

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
