### PR TITLE
`AutoCorrect: contextual` needs rubocop v1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.29.1 (2024-06-12)
+
 - Bump RuboCop requirement to +1.61. ([@ydah])
 
 ## 2.29.0 (2024-06-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Bump RuboCop requirement to +1.61. ([@ydah])
+
 ## 2.29.0 (2024-06-08)
 
 - Support `AutoCorrect: contextual` option for LSP. ([@ydah])

--- a/lib/rubocop/rspec_rails/version.rb
+++ b/lib/rubocop/rspec_rails/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpecRails
     # Version information for the RSpec Rails RuboCop plugin.
     module Version
-      STRING = '2.29.0'
+      STRING = '2.29.1'
     end
   end
 end

--- a/rubocop-rspec_rails.gemspec
+++ b/rubocop-rspec_rails.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.40'
+  spec.add_runtime_dependency 'rubocop', '~> 1.61'
 end


### PR DESCRIPTION
follow up: https://github.com/rubocop/rubocop-rspec/pull/1901

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [-] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
