### PR TITLE
Fix documentation xref

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -4,4 +4,4 @@
 * xref:cops.adoc[Cops]
 * xref:development.adoc[Development]
 * Cops Documentation
-** xref:cops_rspec_rails.adoc[Rails]
+** xref:cops_rspecrails.adoc[Rails]


### PR DESCRIPTION
Antora currently fails with

    [11:39:31.695] ERROR (asciidoctor): target of xref not found: cops_rspec_rails.adoc
      file: docs/modules/ROOT/nav.adoc
      source: https://github.com/rubocop/rubocop-rspec_rails.git (tag: v2.28.0 | start path: docs)
    [11:39:31.742] ERROR (asciidoctor): target of xref not found: cops_rspec_rails.adoc
      file: docs/modules/ROOT/nav.adoc
      source: https://github.com/rubocop/rubocop-rspec_rails.git (tag: v2.29.0 | start path: docs)
    [11:39:31.756] ERROR (asciidoctor): target of xref not found: cops_rspec_rails.adoc
      file: docs/modules/ROOT/nav.adoc
      source: https://github.com/rubocop/rubocop-rspec_rails.git (branch: master | start path: docs)

Notice also how the link to “Cops Documentation → Rails” on https://docs.rubocop.org/rubocop-rspec_rails/index.html does not work.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
