### PR TITLE
Handle unknown HTTP status codes for `RSpecRails::HttpStatus` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Handle unknown HTTP status codes for `RSpecRails/HttpStatus` cop. ([@viralpraxis])
+
 ## 2.30.0 (2024-06-12)
 
 - Fix an runtime error for rubocop-rspec +3.0. ([@bquorning])
@@ -81,4 +83,5 @@
 [@r7kamura]: https://github.com/r7kamura
 [@splattael]: https://github.com/splattael
 [@tmaier]: https://github.com/tmaier
+[@viralpraxis]: https://github.com/viralpraxis
 [@ydah]: https://github.com/ydah

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -115,6 +115,7 @@ This cop inspects only `have_http_status` calls.
 So, this cop does not check if a method starting with `be_*` is used
 when setting for `EnforcedStyle: symbolic` or
 `EnforcedStyle: numeric`.
+This cop is also capable of detecting unknown HTTP status codes.
 
 === Examples
 
@@ -169,6 +170,15 @@ it { is_expected.to be_ok }
 it { is_expected.to be_not_found }
 it { is_expected.to have_http_status :success }
 it { is_expected.to have_http_status :error }
+----
+
+[source,ruby]
+----
+# bad
+it { is_expected.to have_http_status :oki_doki }
+
+# good
+it { is_expected.to have_http_status :ok }
 ----
 
 === Configurable attributes

--- a/spec/rubocop/cop/rspec_rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/http_status_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
         RUBY
       end
     end
+
+    it 'registers an offense for unknown status code' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status("some-custom-string") }
+                                             ^^^^^^^^^^^^^^^^^^^^ Unknown status code.
+      RUBY
+
+      expect_no_corrections
+    end
   end
 
   context 'when EnforcedStyle is `numeric`' do
@@ -131,6 +140,15 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
         it { is_expected.to have_http_status :missing }
         it { is_expected.to have_http_status :redirect }
       RUBY
+    end
+
+    it 'registers an offense for unknown status code' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status("some-custom-string") }
+                                             ^^^^^^^^^^^^^^^^^^^^ Unknown status code.
+      RUBY
+
+      expect_no_corrections
     end
 
     context 'with parenthesis' do
@@ -235,6 +253,15 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
         it { is_expected.to have_http_status :missing }
         it { is_expected.to have_http_status :redirect }
       RUBY
+    end
+
+    it 'registers an offense for unknown status code' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status("some-custom-string") }
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown status code.
+      RUBY
+
+      expect_no_corrections
     end
 
     context 'with parenthesis' do


### PR DESCRIPTION
Consider the following snippet

```ruby
it { expect(response).to have_http_status("some-string") }
```

`RSpecRails::HttpStatus` (configured with default `symbolic` style) reports this as an offense:

```
C: [Correctable] RSpecRails/HttpStatus: Prefer nil over "some-string" to describe HTTP status code. (https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HttpStatus)
    it { expect(response).to have_http_status("some-string") }
```

Autocorrection looks like `have_http_status(nil)` which leads to runtime error.

I expect the cop to ignore unexpected objects passed as http status code.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
