### PR TITLE
Improve test coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,7 +2,7 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 95.17, branch: 85.13
+  minimum_coverage line: 100, branch: 98.41
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end

--- a/.simplecov
+++ b/.simplecov
@@ -2,7 +2,7 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 100, branch: 98.41
+  minimum_coverage line: 100, branch: 100
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end

--- a/lib/rubocop/cop/rspec_rails/http_status.rb
+++ b/lib/rubocop/cop/rspec_rails/http_status.rb
@@ -102,6 +102,10 @@ module RuboCop
             NumericStyleChecker
           when :be_status
             BeStatusStyleChecker
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
 
@@ -124,10 +128,6 @@ module RuboCop
             else
               MSG_UNKNOWN_STATUS_CODE
             end
-          end
-
-          def autocorrectable?
-            true
           end
 
           def current

--- a/lib/rubocop/cop/rspec_rails/inferred_spec_type.rb
+++ b/lib/rubocop/cop/rspec_rails/inferred_spec_type.rb
@@ -93,6 +93,7 @@ module RuboCop
 
         # @param [RuboCop::AST::Node] node
         # @return [Parser::Source::Range]
+        # rubocop:disable Metrics/MethodLength
         def remove_range(node)
           if node.left_sibling
             node.source_range.with(
@@ -102,8 +103,13 @@ module RuboCop
             node.source_range.with(
               end_pos: node.right_sibling.source_range.begin_pos
             )
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         # @param [RuboCop::AST::PairNode] node
         # @return [RuboCop::AST::Node]

--- a/lib/rubocop/cop/rspec_rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec_rails/minitest_assertions.rb
@@ -39,7 +39,9 @@ module RuboCop
           attr_reader :expected, :actual, :failure_message
 
           def self.minitest_assertion
+            # :nocov:
             raise NotImplementedError
+            # :nocov:
           end
 
           def initialize(expected, actual, failure_message)
@@ -62,7 +64,9 @@ module RuboCop
           end
 
           def assertion
+            # :nocov:
             raise NotImplementedError
+            # :nocov:
           end
         end
 

--- a/lib/rubocop/cop/rspec_rails/negation_be_valid.rb
+++ b/lib/rubocop/cop/rspec_rails/negation_be_valid.rb
@@ -64,6 +64,10 @@ module RuboCop
             be_invalid?(node)
           when :be_invalid
             not_to?(node)
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
 
@@ -81,6 +85,10 @@ module RuboCop
             'not_to'
           when :be_invalid
             'to'
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
 
@@ -90,6 +98,10 @@ module RuboCop
             'be_valid'
           when :be_invalid
             'be_invalid'
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
       end

--- a/spec/rubocop/cop/rspec_rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/http_status_spec.rb
@@ -89,6 +89,14 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
 
       expect_no_corrections
     end
+
+    it 'registers no offense when Rack is not loaded' do
+      hide_const('Rack')
+
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status(404) }
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is `numeric`' do
@@ -162,6 +170,14 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
           it { is_expected.to have_http_status(404) }
         RUBY
       end
+    end
+
+    it 'registers no offense when Rack is not loaded' do
+      hide_const('Rack')
+
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status(:not_found) }
+      RUBY
     end
   end
 
@@ -286,6 +302,14 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
           it { is_expected.to be_not_found }
         RUBY
       end
+    end
+
+    it 'registers no offense when Rack is not loaded' do
+      hide_const('Rack')
+
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status(:not_found) }
+      RUBY
     end
   end
 end


### PR DESCRIPTION
In this PR we do two things:

- Instruct SimpleCov to ignore unreachable code. When a `case` or `if` exhausts all branches, but the last `when`/`elsif` documents behavior we don't want to just change it to a fallback `else`. In that case we add a `:noop` or `raise ArgumentError` and use `:nocov:` to tell SimpleCov to ignore it.
- Adds test coverage to spec/rubocop/cop/rspec_rails/http_status_spec.rb for when the rack gem is not loaded.

Those two commits bring line and branch coverage to 100% ✨ 

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
