### PR TITLE
Fix a false negative for `RSpecRails/TravelAround` cop when passed as a proc to a travel method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Handle unknown HTTP status codes for `RSpecRails/HttpStatus` cop. ([@viralpraxis])
+- Fix a false negative for `RSpecRails/TravelAround` cop when passed as a proc to a travel method. ([@ydah])
 
 ## 2.30.0 (2024-06-12)
 

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -456,6 +456,11 @@ around do |example|
   end
 end
 
+# bad
+around do |example|
+  freeze_time(&example)
+end
+
 # good
 before { freeze_time }
 ----

--- a/spec/rubocop/cop/rspec_rails/travel_around_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/travel_around_spec.rb
@@ -67,6 +67,35 @@ RSpec.describe RuboCop::Cop::RSpecRails::TravelAround do
     end
   end
 
+  context 'with `freeze_time` with `&example` in `around`' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        around do |example|
+          freeze_time(&example)
+          ^^^^^^^^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        before { freeze_time }
+
+        around do |example|
+          example.run
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` with `&example` not in `around`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        examples.each do |example|
+          freeze_time(&example)
+        end
+      RUBY
+    end
+  end
+
   context 'with `freeze_time` in `around(:each)`' do
     it 'registers offense' do
       expect_offense(<<~RUBY)
@@ -98,6 +127,29 @@ RSpec.describe RuboCop::Cop::RSpecRails::TravelAround do
           ^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
             example.run
           end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        before { freeze_time }
+
+        around do |example|
+          foo
+
+          example.run
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` with `&example` and another node in `around`' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        around do |example|
+          foo
+
+          freeze_time(&example)
+          ^^^^^^^^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
         end
       RUBY
 


### PR DESCRIPTION
Fixes: #49

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
