### PR TITLE
Use extended `CopsDocumentationGenerator`

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -12,10 +12,8 @@ end
 
 desc 'Generate docs of all cops departments'
 task generate_cops_documentation: :yard_for_generate_documentation do
-  RuboCop::ConfigLoader.inject_defaults!("#{__dir__}/../config/default.yml")
-
   generator = CopsDocumentationGenerator.new(
-    departments: %w[RSpecRails]
+    departments: %w[RSpecRails], plugin_name: 'rubocop-rspec_rails'
   )
   generator.call
 end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop-rspec/pull/2057.

Replacing the workaround implemention `RuboCop::ConfigLoader.inject_defaults!` with the plugin documentation feature supported by `CopsDocumentationGenerator`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
