### PR TITLE
Release v2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.31.0 (2025-03-10)
+
 - Handle unknown HTTP status codes for `RSpecRails/HttpStatus` cop. ([@viralpraxis])
 - Fix a false negative for `RSpecRails/TravelAround` cop when passed as a proc to a travel method. ([@ydah])
 - Make RuboCop RSpecRails work as a RuboCop plugin. ([@bquorning])

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec_rails
 title: RuboCop RSpec Rails
-version: ~
+version: '2.31'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/rspec_rails/version.rb
+++ b/lib/rubocop/rspec_rails/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpecRails
     # Version information for the RSpec Rails RuboCop plugin.
     module Version
-      STRING = '2.30.0'
+      STRING = '2.31.0'
     end
   end
 end


### PR DESCRIPTION
Let’s publish a plugin’ed version ✨

In the words of @koic:

> AFAIK, this is the last extension gem managed by the RuboCop org that has not yet been released as a plugin. With this release, users will be able to consistently use plugins for all officially maintained gems under the RuboCop org.
>
> Having a consistent usage pattern for gems within the RuboCop org is a meaningful step forward.



______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
