### PR TITLE
Add `RSpecRails/HttpStatusNameConsistency` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Add `RSpecRails/HttpStatusNameConsistency` cop. ([@taketo1113])
+
 ## 2.31.0 (2025-03-10)
 
 - Handle unknown HTTP status codes for `RSpecRails/HttpStatus` cop. ([@viralpraxis])
@@ -86,6 +88,7 @@
 [@pirj]: https://github.com/pirj
 [@r7kamura]: https://github.com/r7kamura
 [@splattael]: https://github.com/splattael
+[@taketo1113]: https://github.com/taketo1113
 [@tmaier]: https://github.com/tmaier
 [@viralpraxis]: https://github.com/viralpraxis
 [@ydah]: https://github.com/ydah

--- a/config/default.yml
+++ b/config/default.yml
@@ -35,6 +35,12 @@ RSpecRails/HttpStatus:
   VersionChanged: '2.20'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HttpStatus
 
+RSpecRails/HttpStatusNameConsistency:
+  Description: Enforces consistency by using the current HTTP status names.
+  Enabled: pending
+  VersionAdded: "<<next>>"
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HttpStatusNameConsistency
+
 RSpecRails/InferredSpecType:
   Description: Identifies redundant spec type.
   Enabled: pending

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -5,6 +5,7 @@
 * xref:cops_rspecrails.adoc#rspecrailsavoidsetuphook[RSpecRails/AvoidSetupHook]
 * xref:cops_rspecrails.adoc#rspecrailshavehttpstatus[RSpecRails/HaveHttpStatus]
 * xref:cops_rspecrails.adoc#rspecrailshttpstatus[RSpecRails/HttpStatus]
+* xref:cops_rspecrails.adoc#rspecrailshttpstatusnameconsistency[RSpecRails/HttpStatusNameConsistency]
 * xref:cops_rspecrails.adoc#rspecrailsinferredspectype[RSpecRails/InferredSpecType]
 * xref:cops_rspecrails.adoc#rspecrailsminitestassertions[RSpecRails/MinitestAssertions]
 * xref:cops_rspecrails.adoc#rspecrailsnegationbevalid[RSpecRails/NegationBeValid]

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -211,6 +211,38 @@ it { is_expected.to have_http_status :ok }
 
 * https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HttpStatus
 
+[#rspecrailshttpstatusnameconsistency]
+== RSpecRails/HttpStatusNameConsistency
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| Always
+| <<next>>
+| -
+|===
+
+Enforces consistency by using the current HTTP status names.
+
+[#examples-rspecrailshttpstatusnameconsistency]
+=== Examples
+
+[source,ruby]
+----
+# bad
+it { is_expected.to have_http_status :unprocessable_entity }
+
+# good
+it { is_expected.to have_http_status :unprocessable_content }
+----
+
+[#references-rspecrailshttpstatusnameconsistency]
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HttpStatusNameConsistency
+
 [#rspecrailsinferredspectype]
 == RSpecRails/InferredSpecType
 

--- a/lib/rubocop/cop/rspec_rails/http_status_name_consistency.rb
+++ b/lib/rubocop/cop/rspec_rails/http_status_name_consistency.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpecRails
+      # Enforces consistency by using the current HTTP status names.
+      #
+      # @example
+      #
+      #   # bad
+      #   it { is_expected.to have_http_status :unprocessable_entity }
+      #
+      #   # good
+      #   it { is_expected.to have_http_status :unprocessable_content }
+      #
+      class HttpStatusNameConsistency < ::RuboCop::Cop::Base
+        extend AutoCorrector
+
+        requires_gem 'rack', '>= 3.1.0'
+
+        MSG = 'Use `Prefer `:%<preferred>s` over `:%<current>s`.'
+
+        RESTRICT_ON_SEND = %i[have_http_status].freeze
+
+        PREFERRED_STATUSES = {
+          unprocessable_entity: :unprocessable_content,
+          payload_too_large: :content_too_large
+        }.freeze
+
+        # @!method http_status(node)
+        def_node_matcher :http_status, <<~PATTERN
+          (send nil? :have_http_status ${sym})
+        PATTERN
+
+        def on_send(node)
+          http_status(node) do |arg|
+            check_status_name_consistency(arg)
+          end
+        end
+        alias on_csend on_send
+
+        private
+
+        def check_status_name_consistency(node)
+          return unless node.sym_type? && PREFERRED_STATUSES.key?(node.value)
+
+          current_status = node.value
+          preferred_status = PREFERRED_STATUSES[current_status]
+
+          message = format(MSG, current: current_status,
+                                preferred: preferred_status)
+
+          add_offense(node, message: message) do |corrector|
+            corrector.replace(node, ":#{preferred_status}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_rails_cops.rb
+++ b/lib/rubocop/cop/rspec_rails_cops.rb
@@ -3,6 +3,7 @@
 require_relative 'rspec_rails/avoid_setup_hook'
 require_relative 'rspec_rails/have_http_status'
 require_relative 'rspec_rails/http_status'
+require_relative 'rspec_rails/http_status_name_consistency'
 require_relative 'rspec_rails/inferred_spec_type'
 require_relative 'rspec_rails/minitest_assertions'
 require_relative 'rspec_rails/negation_be_valid'

--- a/spec/rubocop/cop/rspec_rails/http_status_name_consistency_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/http_status_name_consistency_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpecRails::HttpStatusNameConsistency, :config do
+  context 'when Rack is older than 3.1' do
+    let(:gem_versions) { { 'rack' => '3.0.0' } }
+
+    it 'does nothing when using :unprocessable_entity' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status :unprocessable_entity }
+      RUBY
+    end
+
+    it 'does nothing when using :payload_too_large' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status :payload_too_large }
+      RUBY
+    end
+  end
+
+  context 'when Rack is 3.1 or later' do
+    let(:gem_versions) { { 'rack' => '3.1.0' } }
+
+    it 'registers an offense when using :unprocessable_entity' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status :unprocessable_entity }
+                                             ^^^^^^^^^^^^^^^^^^^^^ Use `Prefer `:unprocessable_content` over `:unprocessable_entity`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it { is_expected.to have_http_status :unprocessable_content }
+      RUBY
+    end
+
+    it 'does not register an offense when using :unprocessable_content' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status :unprocessable_content }
+      RUBY
+    end
+
+    it 'registers an offense when using :payload_too_large' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status :payload_too_large }
+                                             ^^^^^^^^^^^^^^^^^^ Use `Prefer `:content_too_large` over `:payload_too_large`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it { is_expected.to have_http_status :content_too_large }
+      RUBY
+    end
+
+    it 'does not register an offense when using :content_too_large' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status :content_too_large }
+      RUBY
+    end
+
+    it 'does nothing when using numeric value' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status 200 }
+      RUBY
+    end
+
+    it 'does nothing when using string value' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status "200" }
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
### Background

In Rack 3.1, several HTTP status symbol names were changed.
For example, the HTTP status 422 was renamed from `:unprocessable_entity` to `:unprocessable_content`.
- https://github.com/rack/rack/pull/2137

To align with these changes in Rack, the `scaffold` and `scaffold_controller` generators in the `rspec-rails` gem have also been updated to use `:unprocessable_content` instead of `:unprocessable_entity`, as shown below:
- https://github.com/rspec/rspec-rails/pull/2860

```diff
  describe "POST /create" do
...
    context "with invalid parameters" do
...
      it "renders a response with 422 status (i.e. to display the 'new' template)" do
        post posts_url, params: { post: invalid_attributes }
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
      end
    end
  end
```

### Details

This Pull Request adds a new cop that detects the use of obsolete HTTP status symbols in existing test code and enforces consistency by using the current HTTP status names.
The cop checks for symbols defined in `Rack::Utils::OBSOLETE_SYMBOL_MAPPINGS`, which currently include `:payload_too_large` and `:unprocessable_entity`.
https://github.com/rack/rack/blob/v3.1.0/lib/rack/utils.rb#L573-L576

### Additional Information

The `rubocop-rails` gem has also introduced a similar cop named `Rails/HttpStatusNameConsistency`,
which enforces consistency by using the current HTTP status names in `app/controllers/*`.
- https://github.com/rubocop/rubocop-rails/pull/1520


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] Added the new cop to `config/default.yml`.
- [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [x] The cop documents examples of good and bad code.
- [x] The tests assert both that bad code is reported and that good code is not reported.
- [x] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
