### PR TITLE
feat: support response assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add `RSpecRails/HttpStatusNameConsistency` cop. ([@taketo1113])
+- Support correcting `assert_response` assertion in in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 
 ## 2.31.0 (2025-03-10)
 
@@ -84,6 +85,7 @@
 [@jojos003]: https://github.com/jojos003
 [@mothonmars]: https://github.com/MothOnMars
 [@mvz]: https://github.com/mvz
+[@nzlaura]: https://github.com/nzlaura
 [@paydaylight]: https://github.com/paydaylight
 [@pirj]: https://github.com/pirj
 [@r7kamura]: https://github.com/r7kamura

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -364,6 +364,7 @@ assert_nil a
 refute_empty(b)
 assert_true(a)
 assert_false(a)
+assert_response :ok
 
 # good
 expect(b).to eq(a)
@@ -374,6 +375,7 @@ expect(a).to eq(nil)
 expect(a).not_to be_empty
 expect(a).to be(true)
 expect(a).to be(false)
+expect(response).to have_http_status(:ok)
 ----
 
 [#references-rspecrailsminitestassertions]

--- a/spec/rubocop/cop/rspec_rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/minitest_assertions_spec.rb
@@ -947,4 +947,90 @@ RSpec.describe RuboCop::Cop::RSpecRails::MinitestAssertions do
       RUBY
     end
   end
+
+  context 'with response assertions' do
+    it 'registers an offense when using `assert_response`' do
+      expect_offense(<<~RUBY)
+        assert_response :redirect
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to have_http_status(:redirect)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to have_http_status(:redirect)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_response` with a number' do
+      expect_offense(<<~RUBY)
+        assert_response 302
+        ^^^^^^^^^^^^^^^^^^^ Use `expect(response).to have_http_status(302)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to have_http_status(302)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_response` with parentheses' do
+      expect_offense(<<~RUBY)
+        assert_response(:success)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to have_http_status(:success)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to have_http_status(:success)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_response` with ' \
+       'failure message' do
+      expect_offense(<<~RUBY)
+        assert_response :success, "expected success status"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to(have_http_status(:success), "expected success status")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to(have_http_status(:success), "expected success status")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_response` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_response(:redirect,
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to(have_http_status(:redirect), "expected redirect status")`.
+                        "expected redirect status")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to(have_http_status(:redirect), "expected redirect status")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_response` with ' \
+       'numeric status' do
+      expect_offense(<<~RUBY)
+        assert_response 200
+        ^^^^^^^^^^^^^^^^^^^ Use `expect(response).to have_http_status(200)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to have_http_status(200)
+      RUBY
+    end
+
+    it 'does not register an offense when using ' \
+       '`expect(response).to have_http_status`' do
+      expect_no_offenses(<<~RUBY)
+        expect(response).to have_http_status(:success)
+      RUBY
+    end
+
+    it 'does not register an offense when using ' \
+       '`expect(response).to have_http_status` with numeric status' do
+      expect_no_offenses(<<~RUBY)
+        expect(response).to have_http_status(200)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR adding support for correcting response assertions alongside other minitest assertions. 

I have used `Struct` for the `actual` param for this assertion, because the "actual" is the test-local @response property, and the way the minitests are initialised require `actual` to be passed as a param.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
