### PR TITLE
Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
+
 ## 2.32.0 (2025-11-12)
 
 - Add `RSpecRails/HttpStatusNameConsistency` cop. ([@taketo1113])

--- a/lib/rubocop/cop/rspec_rails/negation_be_valid.rb
+++ b/lib/rubocop/cop/rspec_rails/negation_be_valid.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         # @!method not_to?(node)
         def_node_matcher :not_to?, <<~PATTERN
-          (send ... :not_to (send nil? :be_valid ...))
+          (send ... {:not_to :to_not} (send nil? :be_valid ...))
         PATTERN
 
         # @!method be_invalid?(node)

--- a/spec/rubocop/cop/rspec_rails/negation_be_valid_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/negation_be_valid_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe RuboCop::Cop::RSpecRails::NegationBeValid do
       RUBY
     end
 
+    it 'registers an offense when using ' \
+       '`expect(...).to_not be_valid`' do
+      expect_offense(<<~RUBY)
+        expect(foo).to_not be_valid
+                    ^^^^^^^^^^^^^^^ Use `expect(...).to be_invalid`.
+      RUBY
+    end
+
     it 'does not register an offense when using ' \
        '`expect(...).to be_invalid`' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fixes: #70

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
