### PR TITLE
CI: Use latest Ruby where possible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: bundle exec rake confirm_config documentation_syntax_check confirm_documentation
 
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: bundle exec rake spec
 
@@ -74,7 +74,7 @@ jobs:
           echo "gem 'rubocop', github: 'rubocop/rubocop'" > Gemfile.local
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
@@ -94,7 +94,7 @@ jobs:
           echo "gem 'rubocop-rspec', github: 'rubocop/rubocop-rspec'" > Gemfile.local
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
@@ -115,6 +115,6 @@ jobs:
           EOF
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0"
+          ruby-version: ruby
           bundler-cache: true
       - run: NO_COVERAGE=true bundle exec rake spec


### PR DESCRIPTION
By always using the latest stable Ruby version, the CI configuration will require less updating when a new Ruby version is released.