### PR TITLE
feat: support correcting assert_redirected_to in RSpec/Rails/MinitestAssertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
+- Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 
 ## 2.32.0 (2025-11-12)
 

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -365,6 +365,7 @@ refute_empty(b)
 assert_true(a)
 assert_false(a)
 assert_response :ok
+assert_redirected_to '/users'
 
 # good
 expect(b).to eq(a)
@@ -376,6 +377,7 @@ expect(a).not_to be_empty
 expect(a).to be(true)
 expect(a).to be(false)
 expect(response).to have_http_status(:ok)
+expect(response).to redirect_to('/users')
 ----
 
 [#references-rspecrailsminitestassertions]

--- a/spec/rubocop/cop/rspec_rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/minitest_assertions_spec.rb
@@ -1033,4 +1033,105 @@ RSpec.describe RuboCop::Cop::RSpecRails::MinitestAssertions do
       RUBY
     end
   end
+
+  context 'with redirect assertions' do
+    it 'registers an offense when using `assert_redirected_to` with a path' do
+      expect_offense(<<~RUBY)
+        assert_redirected_to '/users'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to redirect_to('/users')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to redirect_to('/users')
+      RUBY
+    end
+
+    # rubocop:disable Layout/LineLength
+    it 'registers an offense when using `assert_redirected_to` with parentheses' do
+      # rubocop:enable Layout/LineLength
+      expect_offense(<<~RUBY)
+        assert_redirected_to('/users')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to redirect_to('/users')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to redirect_to('/users')
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_redirected_to` with ' \
+       'controller and action' do
+      expect_offense(<<~RUBY)
+        assert_redirected_to controller: 'users', action: 'show'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to redirect_to(controller: 'users', action: 'show')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to redirect_to(controller: 'users', action: 'show')
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_redirected_to` with ' \
+       'failure message' do
+      expect_offense(<<~RUBY)
+        assert_redirected_to '/users', "expected redirect to users"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to(redirect_to('/users'), "expected redirect to users")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to(redirect_to('/users'), "expected redirect to users")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_redirected_to` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_redirected_to('/users',
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to(redirect_to('/users'), "expected redirect to users")`.
+                             "expected redirect to users")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to(redirect_to('/users'), "expected redirect to users")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_redirected_to` with ' \
+       'a URL' do
+      expect_offense(<<~RUBY)
+        assert_redirected_to 'http://example.com/users'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to redirect_to('http://example.com/users')`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to redirect_to('http://example.com/users')
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_redirected_to` with ' \
+       'a named route' do
+      expect_offense(<<~RUBY)
+        assert_redirected_to users_path
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(response).to redirect_to(users_path)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response).to redirect_to(users_path)
+      RUBY
+    end
+
+    it 'does not register an offense when using ' \
+       '`expect(response).to redirect_to`' do
+      expect_no_offenses(<<~RUBY)
+        expect(response).to redirect_to('/users')
+      RUBY
+    end
+
+    it 'does not register an offense when using ' \
+       '`expect(response).to redirect_to` with controller and action' do
+      expect_no_offenses(<<~RUBY)
+        expect(response).to redirect_to(controller: 'users', action: 'show')
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR adding support for correcting redirect assertions alongside other minitest assertions

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
