### PR TITLE
CI: Test RSpec 4 prerelease on rspec main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,15 +103,15 @@ jobs:
     name: RSpec 4
     steps:
       - uses: actions/checkout@v6
-      - name: Use latest RSpec 4 from `4-0-dev` branch
+      - name: Use latest RSpec 4 from `main` branch
         run: |
           sed -e "/^gem 'rspec/d" -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rspec', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-core', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-expectations', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-mocks', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-support', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-core', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-expectations', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-mocks', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-support', github: 'rspec/rspec', branch: 'main'
           EOF
       - uses: ruby/setup-ruby@v1
         with:

--- a/spec/smoke_tests/weird_rspec_spec.rb
+++ b/spec/smoke_tests/weird_rspec_spec.rb
@@ -80,8 +80,14 @@ RSpec.describe 'Weirdness' do
 
   context 'test' do
     include_examples 'weird rspec'
-    include_examples('weird rspec', serious: true) do
-      it_behaves_like :something
+    if RSpec::Core::Version::STRING < '4.0'
+      include_examples('weird rspec', serious: true) do
+        it_behaves_like :something
+      end
+    else
+      it_behaves_like('weird rspec', serious: true) do
+        it_behaves_like :something
+      end
     end
   end
 


### PR DESCRIPTION
[The 4-0-dev branch](https://github.com/rspec/rspec/tree/4-0-dev) hasn't been used in a couple of years; the RSpec 4.0-pre development seems to happen on [the main branch](https://github.com/rspec/rspec/tree/main).

Related: ccb23d41306757baa22f58716645f1b3201332f3