### PR TITLE
Fix RSpecRails/TravelAround autocorrect to preserve indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])
+- Fix `RSpecRails/TravelAround` autocorrection to keep the indentation of the surrounding `around` block. ([@eugeneius])
 
 ## 2.32.0 (2025-11-12)
 
@@ -88,6 +89,7 @@
 [@anthony-robin]: https://github.com/anthony-robin
 [@bquorning]: https://github.com/bquorning
 [@corydiamand]: https://github.com/corydiamand
+[@eugeneius]: https://github.com/eugeneius
 [@fatkodima]: https://github.com/fatkodima
 [@g-rath]: https://github.com/G-Rath
 [@jojos003]: https://github.com/jojos003

--- a/lib/rubocop/cop/rspec_rails/travel_around.rb
+++ b/lib/rubocop/cop/rspec_rails/travel_around.rb
@@ -82,8 +82,10 @@ module RuboCop
 
           add_offense(node) do |corrector|
             corrector.replace(node, node.body.source)
-            corrector.insert_before(around_node,
-                                    "before { #{run_node.source} }\n\n")
+            corrector.insert_before(
+              around_node,
+              "before { #{run_node.source} }\n\n#{indent(around_node)}"
+            )
           end
         end
 
@@ -95,7 +97,7 @@ module RuboCop
             corrector.replace(node, "#{lvar.name}.run")
             corrector.insert_before(
               around_node,
-              "before { #{node.method_name} }\n\n"
+              "before { #{node.method_name} }\n\n#{indent(around_node)}"
             )
           end
         end

--- a/spec/rubocop/cop/rspec_rails/travel_around_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/travel_around_spec.rb
@@ -206,4 +206,60 @@ RSpec.describe RuboCop::Cop::RSpecRails::TravelAround do
       RUBY
     end
   end
+
+  context 'with `freeze_time` in an indented `around`' do
+    it 'registers offense and preserves indentation' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          context 'when bar' do
+            around do |example|
+              freeze_time do
+              ^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
+                example.run
+              end
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe Foo do
+          context 'when bar' do
+            before { freeze_time }
+
+            around do |example|
+              example.run
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` with `&example` in an indented `around`' do
+    it 'registers offense and preserves indentation' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          context 'when bar' do
+            around do |example|
+              freeze_time(&example)
+              ^^^^^^^^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe Foo do
+          context 'when bar' do
+            before { freeze_time }
+
+            around do |example|
+              example.run
+            end
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
The autocorrection inserted the new `before` block above the `around` block, but left the `around` block unindented.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.