### PR TITLE
Fix RSpecRails/HttpStatus unknown symbol handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])
 - Fix `RSpecRails/TravelAround` autocorrection to keep the indentation of the surrounding `around` block. ([@eugeneius])
+- Fix `RSpecRails/HttpStatus` to detect unknown symbolic HTTP statuses and handle custom numeric string statuses consistently. ([@ydah])
 
 ## 2.32.0 (2025-11-12)
 

--- a/lib/rubocop/cop/rspec_rails/http_status.rb
+++ b/lib/rubocop/cop/rspec_rails/http_status.rb
@@ -142,16 +142,44 @@ module RuboCop
             node.sym_type? && ALLOWED_STATUSES.include?(node.value)
           end
 
+          def known_status_symbol?
+            node.sym_type? &&
+              ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(node.value)
+          end
+
+          def known_status_code?
+            numeric_status_code? &&
+              ::Rack::Utils::SYMBOL_TO_STATUS_CODE.value?(status_code_number)
+          end
+
           def custom_http_status_code?
-            node.int_type? &&
-              !::Rack::Utils::SYMBOL_TO_STATUS_CODE.value?(node.source.to_i)
+            numeric_status_code? && !known_status_code?
+          end
+
+          def numeric_status_code?
+            node.int_type? || numeric_string?
+          end
+
+          def numeric_string?
+            node.str_type? && node.value.match?(/\A\d+\z/)
+          end
+
+          def status_code_number
+            node.value.to_i
+          end
+
+          def status_code_symbol
+            ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(status_code_number)
           end
         end
 
         # :nodoc:
         class SymbolicStyleChecker < StyleCheckerBase
           def offensive?
-            !node.sym_type? && !custom_http_status_code?
+            return false if allowed_symbol? || known_status_symbol?
+            return false if custom_http_status_code?
+
+            true
           end
 
           def autocorrectable?
@@ -165,18 +193,17 @@ module RuboCop
           private
 
           def symbol
-            ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(number)
-          end
-
-          def number
-            node.value.to_i
+            status_code_symbol if known_status_code?
           end
         end
 
         # :nodoc:
         class NumericStyleChecker < StyleCheckerBase
           def offensive?
-            !node.int_type? && !allowed_symbol?
+            return false if node.int_type? || allowed_symbol?
+            return false if custom_http_status_code?
+
+            true
           end
 
           def autocorrectable?
@@ -189,20 +216,19 @@ module RuboCop
 
           private
 
-          def symbol
-            node.value
-          end
-
           def number
-            ::Rack::Utils::SYMBOL_TO_STATUS_CODE[symbol.to_sym]
+            return status_code_number if known_status_code?
+
+            ::Rack::Utils::SYMBOL_TO_STATUS_CODE[node.value.to_sym]
           end
         end
 
         # :nodoc:
         class BeStatusStyleChecker < StyleCheckerBase
           def offensive?
-            (!node.sym_type? && !custom_http_status_code?) ||
-              (!node.int_type? && !allowed_symbol?)
+            return false if allowed_symbol? || custom_http_status_code?
+
+            true
           end
 
           def autocorrectable?
@@ -220,30 +246,18 @@ module RuboCop
           private
 
           def status_code
-            if node.sym_type?
+            if known_status_symbol?
               node.value
-            elsif node.int_type?
-              symbol
+            elsif known_status_code?
+              status_code_symbol
             else
               normalize_str
             end
           end
 
-          def symbol
-            ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(number)
-          end
-
-          def number
-            node.value.to_i
-          end
-
           def normalize_str
             str = node.value.to_s
-            if str.match?(/\A\d+\z/)
-              ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(str.to_i)
-            elsif ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(str.to_sym)
-              str
-            end
+            str if ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key?(str.to_sym)
           end
         end
       end

--- a/spec/rubocop/cop/rspec_rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/http_status_spec.rb
@@ -62,9 +62,19 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
       RUBY
     end
 
+    it 'registers an offense when using unknown symbolic value' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status :oki_doki }
+                                             ^^^^^^^^^ Unknown status code.
+      RUBY
+
+      expect_no_corrections
+    end
+
     it 'does not register an offense when using custom HTTP code' do
       expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status 550 }
+        it { is_expected.to have_http_status "550" }
       RUBY
     end
 
@@ -135,9 +145,27 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
       RUBY
     end
 
+    it 'registers an offense when using numeric string value' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status "200" }
+                                             ^^^^^ Prefer `200` over `"200"` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it { is_expected.to have_http_status 200 }
+      RUBY
+    end
+
     it 'does not register an offense when using numeric value' do
       expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status 200 }
+      RUBY
+    end
+
+    it 'does not register an offense when using custom HTTP code' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status 550 }
+        it { is_expected.to have_http_status "550" }
       RUBY
     end
 
@@ -148,6 +176,15 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
         it { is_expected.to have_http_status :missing }
         it { is_expected.to have_http_status :redirect }
       RUBY
+    end
+
+    it 'registers an offense when using unknown symbolic value' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status :oki_doki }
+                                             ^^^^^^^^^ Unknown status code.
+      RUBY
+
+      expect_no_corrections
     end
 
     it 'registers an offense for unknown status code' do
@@ -262,6 +299,13 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
       RUBY
     end
 
+    it 'does not register an offense when using custom HTTP code' do
+      expect_no_offenses(<<~RUBY)
+        it { is_expected.to have_http_status 550 }
+        it { is_expected.to have_http_status "550" }
+      RUBY
+    end
+
     it 'does not register an offense when using allowed symbols' do
       expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status :error }
@@ -275,6 +319,15 @@ RSpec.describe RuboCop::Cop::RSpecRails::HttpStatus do
       expect_offense(<<~RUBY)
         it { is_expected.to have_http_status("some-custom-string") }
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown status code.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense when using unknown symbolic value' do
+      expect_offense(<<~RUBY)
+        it { is_expected.to have_http_status :oki_doki }
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Unknown status code.
       RUBY
 
       expect_no_corrections


### PR DESCRIPTION
`RSpecRails/HttpStatus` documented `have_http_status :oki_doki` as bad, but the symbolic style checker accepted any symbol. Unknown symbols are now reported as unknown status codes across all styles, and custom numeric string statuses are handled consistently with custom integer statuses.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
