### PR TITLE
Fix RSpecRails/ReceivePerformLater negative expectation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])
 - Fix `RSpecRails/TravelAround` autocorrection to keep the indentation of the surrounding `around` block. ([@eugeneius])
+- Fix `RSpecRails/ReceivePerformLater` offense messages for negative expectations. ([@ydah])
 
 ## 2.32.0 (2025-11-12)
 

--- a/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
+++ b/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
@@ -35,7 +35,8 @@ module RuboCop
       #     .at(Date.tomorrow.noon)
       #
       class ReceivePerformLater < ::RuboCop::Cop::Base
-        MSG = 'Prefer `expect { ... }.to have_enqueued_job(%<job_class>s)` ' \
+        MSG = 'Prefer `expect { ... }.%<runner>s ' \
+              'have_enqueued_job(%<job_class>s)` ' \
               'over `%<receiver>s(%<job_class>s).%<to>s ' \
               '%<matcher>s(:perform_later)`.'
 
@@ -78,6 +79,7 @@ module RuboCop
           format(MSG,
                  receiver: expect_node.method_name,
                  job_class: job_class.source,
+                 runner: runner_node.method_name,
                  to: runner_node.method_name,
                  matcher: matcher_node.method_name)
         end

--- a/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
     expect_offense(<<~RUBY)
       it 'does not enqueue a job' do
         expect(MyJob).not_to receive(:perform_later)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).not_to receive(:perform_later)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.not_to have_enqueued_job(MyJob)` over `expect(MyJob).not_to receive(:perform_later)`.
         do_something
       end
     RUBY
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
     expect_offense(<<~RUBY)
       it 'does not enqueue a job' do
         expect(MyJob).to_not receive(:perform_later)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to_not receive(:perform_later)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to_not have_enqueued_job(MyJob)` over `expect(MyJob).to_not receive(:perform_later)`.
         do_something
       end
     RUBY
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
         allow(MyJob).to receive(:perform_later)
         do_something
         expect(MyJob).not_to have_received(:perform_later)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).not_to have_received(:perform_later)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.not_to have_enqueued_job(MyJob)` over `expect(MyJob).not_to have_received(:perform_later)`.
       end
     RUBY
   end
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
         allow(MyJob).to receive(:perform_later)
         do_something
         expect(MyJob).to_not have_received(:perform_later)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to_not have_received(:perform_later)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to_not have_enqueued_job(MyJob)` over `expect(MyJob).to_not have_received(:perform_later)`.
       end
     RUBY
   end
@@ -311,7 +311,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
     expect_offense(<<~RUBY)
       it 'uses expect and not_to' do
         expect(MyJob).not_to receive(:perform_later)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).not_to receive(:perform_later)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.not_to have_enqueued_job(MyJob)` over `expect(MyJob).not_to receive(:perform_later)`.
       end
     RUBY
   end
@@ -320,7 +320,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
     expect_offense(<<~RUBY)
       it 'uses expect and to_not' do
         expect(MyJob).to_not receive(:perform_later)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to_not receive(:perform_later)`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to_not have_enqueued_job(MyJob)` over `expect(MyJob).to_not receive(:perform_later)`.
       end
     RUBY
   end


### PR DESCRIPTION
`RSpecRails/ReceivePerformLater` suggested `expect { ... }.to have_enqueued_job(...)` even for negative expectations such as `expect(MyJob).not_to receive(:perform_later)`. The suggested `have_enqueued_job` expectation now uses the same runner as the original expectation, so `to`, `not_to`, and `to_not` are preserved in the offense message.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
