### PR TITLE
Fix RSpecRails/ReceivePerformLater nested matcher false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])
 - Fix `RSpecRails/ReceivePerformLater` offense range to exclude chains after the expectation. ([@ydah])
+- Fix a false positive for `RSpecRails/ReceivePerformLater` when `receive(:perform_later)` is used inside another matcher. ([@ydah])
 - Fix `RSpecRails/TravelAround` autocorrection to keep the indentation of the surrounding `around` block. ([@eugeneius])
 - Fix `RSpecRails/ReceivePerformLater` offense messages for negative expectations. ([@ydah])
 

--- a/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
+++ b/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
@@ -57,18 +57,23 @@ module RuboCop
         def on_send(node)
           return unless receive_perform_later?(node)
           return unless (runner_node = find_runner_node(node))
+          return unless runner_matcher?(node, runner_node)
 
+          register_offense(node, runner_node)
+        end
+
+        private
+
+        def register_offense(matcher_node, runner_node)
           expect_node = runner_node.receiver
           return unless expect_or_allow?(expect_node)
-          return if allow_receive_combination?(expect_node, node)
+          return if allow_receive_combination?(expect_node, matcher_node)
 
           job_class = expect_node.first_argument
           add_offense(runner_node,
                       message: offense_message(expect_node, job_class,
-                                               runner_node, node))
+                                               runner_node, matcher_node))
         end
-
-        private
 
         def allow_receive_combination?(expect_node, matcher_node)
           expect_node.method?(:allow) && matcher_node.method?(:receive)
@@ -85,6 +90,12 @@ module RuboCop
 
         def find_runner_node(node)
           node.each_ancestor(:send).find { |ancestor| runner?(ancestor) }
+        end
+
+        def runner_matcher?(matcher_node, runner_node)
+          node = runner_node.first_argument
+          node = node.receiver while node&.send_type? && node != matcher_node
+          node == matcher_node
         end
 
         def runner?(node)

--- a/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
@@ -224,6 +224,15 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
     RUBY
   end
 
+  it 'does not register an offense when `receive(:perform_later)` ' \
+     'is an argument to another matcher' do
+    expect_no_offenses(<<~RUBY)
+      it 'uses receive perform_later inside another matcher' do
+        expect(MyJob).to custom_matcher(receive(:perform_later))
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using ' \
      '`expect(instance).to receive(:perform_later)`' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
`RSpecRails/ReceivePerformLater` could register an offense when `receive(:perform_later)` was only an argument to another matcher, such as `expect(MyJob).to custom_matcher(receive(:perform_later))`. The cop now only registers an offense when the `receive` or `have_received` matcher is the expectation runner's matcher, including chained matcher calls like `.with(...)`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
