### PR TITLE
Fix RSpecRails/ReceivePerformLater offense range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])
+- Fix `RSpecRails/ReceivePerformLater` offense range to exclude chains after the expectation. ([@ydah])
 - Fix `RSpecRails/TravelAround` autocorrection to keep the indentation of the surrounding `around` block. ([@eugeneius])
 
 ## 2.32.0 (2025-11-12)

--- a/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
+++ b/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
@@ -62,8 +62,7 @@ module RuboCop
           return if allow_receive_combination?(expect_node, node)
 
           job_class = expect_node.first_argument
-          offense_node = find_offense_range(runner_node)
-          add_offense(offense_node,
+          add_offense(runner_node,
                       message: offense_message(expect_node, job_class,
                                                runner_node, node))
         end
@@ -84,16 +83,6 @@ module RuboCop
 
         def find_runner_node(node)
           node.each_ancestor(:send).find { |ancestor| runner?(ancestor) }
-        end
-
-        def find_offense_range(runner_node)
-          current = runner_node
-          current = current.parent while chained_send?(current)
-          current
-        end
-
-        def chained_send?(node)
-          node.parent&.send_type? && node.parent.receiver == node
         end
 
         def runner?(node)

--- a/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
@@ -434,17 +434,15 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
     expect_offense(<<~RUBY)
       it 'chaining after to' do
         result = expect(MyJob).to(receive(:perform_later)).tap { |x| x }
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to receive(:perform_later)`.
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to receive(:perform_later)`.
       end
     RUBY
   end
 
   it 'registers offense with deeply nested method chain' do
-    # This tests the case where find_offense_range traverses up
-    # until it reaches a node whose parent is nil
     expect_offense(<<~RUBY)
       expect(MyJob).to(receive(:perform_later)).foo.bar.baz
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to receive(:perform_later)`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to receive(:perform_later)`.
     RUBY
   end
 end


### PR DESCRIPTION
`RSpecRails/ReceivePerformLater` expanded the offense range through method chains after the expectation, so examples like `expect(MyJob).to(receive(:perform_later)).tap { ... }` highlighted the trailing `.tap` call too. The cop now reports the expectation runner itself, keeping the range focused on `expect(...).to receive(...)` while leaving later chains outside the offense.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
