### PR TITLE
Support described_class in RSpecRails/ReceivePerformLater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])
+- Support `described_class` for `RSpecRails/ReceivePerformLater`. ([@ydah])
 - Fix `RSpecRails/TravelAround` autocorrection to keep the indentation of the surrounding `around` block. ([@eugeneius])
 
 ## 2.32.0 (2025-11-12)

--- a/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
+++ b/lib/rubocop/cop/rspec_rails/receive_perform_later.rb
@@ -50,7 +50,7 @@ module RuboCop
 
         # @!method expect_or_allow?(node)
         def_node_matcher :expect_or_allow?, <<~PATTERN
-          (send nil? {:expect :allow} const_type?)
+          (send nil? {:expect :allow} {const_type? (send nil? :described_class)})
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/receive_perform_later_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
   end
 
   it 'registers an offense when using ' \
+     '`expect(described_class).to receive(:perform_later)`' do
+    expect_offense(<<~RUBY)
+      it 'enqueues the described job' do
+        expect(described_class).to receive(:perform_later)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(described_class)` over `expect(described_class).to receive(:perform_later)`.
+        do_something
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using ' \
      '`expect(Job).not_to receive(:perform_later)`' do
     expect_offense(<<~RUBY)
       it 'does not enqueue a job' do
@@ -75,6 +86,18 @@ RSpec.describe RuboCop::Cop::RSpecRails::ReceivePerformLater do
         do_something
         expect(MyJob).to have_received(:perform_later)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(MyJob)` over `expect(MyJob).to have_received(:perform_later)`.
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using ' \
+     '`expect(described_class).to have_received(:perform_later)`' do
+    expect_offense(<<~RUBY)
+      it 'enqueues the described job' do
+        allow(described_class).to receive(:perform_later)
+        do_something
+        expect(described_class).to have_received(:perform_later)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect { ... }.to have_enqueued_job(described_class)` over `expect(described_class).to have_received(:perform_later)`.
       end
     RUBY
   end


### PR DESCRIPTION
`RSpecRails/ReceivePerformLater` only treated constant arguments to `expect` and `allow` as job classes, so common job spec code like `expect(described_class).to receive(:perform_later)` was ignored. The cop now also accepts `described_class` as the job class expression and reports offenses for both `receive` and `have_received` forms.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
