### PR TITLE
Fix RSpecRails/TravelAround around example matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix offense message for `RSpecRails/HttpStatusNameConsistency` cop. ([@fatkodima])
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
+- Fix false positives for `RSpecRails/TravelAround` when travel does not directly wrap the around example. ([@ydah])
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])
 - Fix `RSpecRails/TravelAround` autocorrection to keep the indentation of the surrounding `around` block. ([@eugeneius])

--- a/lib/rubocop/cop/rspec_rails/travel_around.rb
+++ b/lib/rubocop/cop/rspec_rails/travel_around.rb
@@ -45,7 +45,7 @@ module RuboCop
           (block
             $(send nil? TRAVEL_METHOD_NAMES ...)
             (args ...)
-            (send _ :run)
+            (send (lvar _) :run)
           )
         PATTERN
 
@@ -76,15 +76,16 @@ module RuboCop
 
         private
 
-        def run_in_travel(node, run_node)
-          around_node = extract_surrounding_around_block(run_node)
+        def run_in_travel(node, travel_node)
+          around_node = extract_surrounding_around_block(node)
           return unless around_node
+          return unless matching_run_receiver?(node.body, around_node)
 
           add_offense(node) do |corrector|
             corrector.replace(node, node.body.source)
             corrector.insert_before(
               around_node,
-              "before { #{run_node.source} }\n\n#{indent(around_node)}"
+              "before { #{travel_node.source} }\n\n#{indent(around_node)}"
             )
           end
         end
@@ -92,6 +93,7 @@ module RuboCop
         def travel_with_block_pass(node, lvar)
           around_node = extract_surrounding_around_block(node)
           return unless around_node
+          return unless lvar.name == around_argument_name(around_node)
 
           add_offense(node) do |corrector|
             corrector.replace(node, "#{lvar.name}.run")
@@ -106,8 +108,22 @@ module RuboCop
         # @return [RuboCop::AST::BlockNode, nil]
         def extract_surrounding_around_block(node)
           node.each_ancestor(:block).find do |ancestor|
-            match_around_each?(ancestor)
+            match_around_each?(ancestor) &&
+              direct_child_of_around_body?(node, ancestor)
           end
+        end
+
+        def direct_child_of_around_body?(node, around_node)
+          node.parent == around_node ||
+            (node.parent.begin_type? && node.parent.parent == around_node)
+        end
+
+        def matching_run_receiver?(run_node, around_node)
+          run_node.receiver.children.first == around_argument_name(around_node)
+        end
+
+        def around_argument_name(around_node)
+          around_node.first_argument&.name
         end
       end
     end

--- a/spec/rubocop/cop/rspec_rails/travel_around_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/travel_around_spec.rb
@@ -67,6 +67,78 @@ RSpec.describe RuboCop::Cop::RSpecRails::TravelAround do
     end
   end
 
+  context 'with `freeze_time` in `around` using another receiver' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        around do |example|
+          other = example
+          freeze_time do
+            other.run
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` in `around` using another block pass' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        around do |example|
+          other = proc {}
+          freeze_time(&other)
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` nested in another block in `around`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        around do |example|
+          [1].each do
+            freeze_time do
+              example.run
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` in `around` without a block argument' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        around do
+          example = double
+          freeze_time do
+            example.run
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` matching a custom around block argument' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        around do |test_case|
+          freeze_time do
+          ^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
+            test_case.run
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        before { freeze_time }
+
+        around do |test_case|
+          test_case.run
+        end
+      RUBY
+    end
+  end
+
   context 'with `freeze_time` with `&example` in `around`' do
     it 'registers offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
`RSpecRails/TravelAround` matched `run` calls and block passes without confirming they belonged to the surrounding `around` example. This could autocorrect cases such as `freeze_time { other.run }`, `freeze_time(&other)`, or nested travel blocks inside another block. The cop now requires the travel call to be directly in the `around` body and requires the `run` receiver or block pass variable to match the `around` block argument.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
