### PR TITLE
Fix RSpecRails/AvoidSetupHook example group scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix offense message for `RSpecRails/HttpStatusNameConsistency` cop. ([@fatkodima])
+- Fix `RSpecRails/AvoidSetupHook` to only check setup hooks inside example groups and support numbered blocks. ([@ydah])
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])

--- a/lib/rubocop/cop/rspec_rails/avoid_setup_hook.rb
+++ b/lib/rubocop/cop/rspec_rails/avoid_setup_hook.rb
@@ -16,23 +16,34 @@ module RuboCop
       #     allow(foo).to receive(:bar)
       #   end
       #
-      class AvoidSetupHook < ::RuboCop::Cop::Base
+      class AvoidSetupHook < ::RuboCop::Cop::RSpec::Base
         extend AutoCorrector
 
         MSG = 'Use `before` instead of `setup`.'
 
-        # @!method setup_call(node)
-        def_node_matcher :setup_call, <<~PATTERN
-          (block
-            $(send nil? :setup)
-            (args) _)
-        PATTERN
+        def on_block(node) # rubocop:disable InternalAffairs/ItblockHandler
+          return unless (setup = setup_call(node))
+          return unless inside_example_group?(node)
 
-        def on_block(node) # rubocop:disable InternalAffairs/ItblockHandler, InternalAffairs/NumblockHandler
-          setup_call(node) do |setup|
-            add_offense(node) do |corrector|
-              corrector.replace setup, 'before'
-            end
+          add_offense(node) do |corrector|
+            corrector.replace setup, 'before'
+          end
+        end
+        alias on_numblock on_block
+
+        private
+
+        def setup_call(node)
+          send_node = node.send_node
+          return unless send_node.method?(:setup)
+          return if send_node.receiver
+
+          send_node
+        end
+
+        def inside_example_group?(node)
+          node.each_ancestor(:block).any? do |ancestor|
+            example_group?(ancestor)
           end
         end
       end

--- a/spec/rubocop/cop/rspec_rails/avoid_setup_hook_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/avoid_setup_hook_spec.rb
@@ -3,31 +3,64 @@
 RSpec.describe RuboCop::Cop::RSpecRails::AvoidSetupHook do
   it 'registers an offense for `setup`' do
     expect_offense(<<~RUBY)
-      setup do
-      ^^^^^^^^ Use `before` instead of `setup`.
-        allow(foo).to receive(:bar)
+      RSpec.describe Foo do
+        setup do
+        ^^^^^^^^ Use `before` instead of `setup`.
+          allow(foo).to receive(:bar)
+        end
       end
     RUBY
 
     expect_correction(<<~RUBY)
-      before do
-        allow(foo).to receive(:bar)
+      RSpec.describe Foo do
+        before do
+          allow(foo).to receive(:bar)
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for numbered block `setup`' do
+    expect_offense(<<~RUBY)
+      RSpec.describe Foo do
+        setup { _1 }
+        ^^^^^^^^^^^^ Use `before` instead of `setup`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe Foo do
+        before { _1 }
       end
     RUBY
   end
 
   it 'does not register an offense for `before`' do
     expect_no_offenses(<<~RUBY)
-      before do
-        allow(foo).to receive(:bar)
+      RSpec.describe Foo do
+        before do
+          allow(foo).to receive(:bar)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `setup` outside an example group' do
+    expect_no_offenses(<<~RUBY)
+      SomeDSL.configure do
+        setup do
+          prepare
+        end
       end
     RUBY
   end
 
   it 'does not register an offense for an unrelated `setup` call' do
     expect_no_offenses(<<~RUBY)
-      navigation.setup do
-        direction 'to infinity!'
+      RSpec.describe Foo do
+        navigation.setup do
+          direction 'to infinity!'
+        end
       end
     RUBY
   end


### PR DESCRIPTION
`RSpecRails/AvoidSetupHook` reported receiverless `setup` blocks anywhere, even outside RSpec example groups. The cop now uses the RSpec cop base and only reports setup hooks inside an example group, while also handling numbered block setup hooks such as `setup { _1 }`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
