### PR TITLE
Fix RSpecRails/MinitestAssertions quoted predicate symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix offense message for `RSpecRails/HttpStatusNameConsistency` cop. ([@fatkodima])
+- Fix `RSpecRails/MinitestAssertions` autocorrection for quoted predicate symbols. ([@ydah])
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
 - Supporting correcting `assest_redirected_to` in `RSpec/Rails/MinitestAssertions`. ([@nzlaura])
 - Add new `RSpecRails/ReceivePerformLater` cop. ([@ydah])

--- a/lib/rubocop/cop/rspec_rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec_rails/minitest_assertions.rb
@@ -204,13 +204,27 @@ module RuboCop
           PATTERN
 
           def self.match(subject, predicate, failure_message)
-            return nil unless predicate.value.end_with?('?')
+            predicate_name = predicate.value.to_s
+            return nil unless predicate_name.end_with?('?')
 
-            new(predicate, subject, failure_message.first)
+            matcher_name = predicate_name.delete_suffix('?')
+            return nil unless valid_matcher_name?(matcher_name)
+
+            new(predicate, subject, failure_message.first, matcher_name)
+          end
+
+          def self.valid_matcher_name?(matcher_name)
+            matcher_name.match?(/\A\w+\z/)
+          end
+
+          def initialize(expected, actual, failure_message, matcher_name)
+            super(expected, actual, failure_message)
+
+            @matcher_name = matcher_name
           end
 
           def assertion
-            "be_#{expected.delete_prefix(':').delete_suffix('?')}"
+            "be_#{@matcher_name}"
           end
         end
 

--- a/spec/rubocop/cop/rspec_rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/minitest_assertions_spec.rb
@@ -844,6 +844,25 @@ RSpec.describe RuboCop::Cop::RSpecRails::MinitestAssertions do
     end
 
     it 'registers an offense when using `assert_predicate` with ' \
+       'a quoted predicate symbol' do
+      expect_offense(<<~RUBY)
+        assert_predicate a, :"valid?"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to be_valid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to be_valid
+      RUBY
+    end
+
+    it 'does not register an offense when the predicate symbol cannot ' \
+       'be converted to a matcher name' do
+      expect_no_offenses(<<~RUBY)
+        assert_predicate a, :"valid-name?"
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_predicate` with ' \
        'an actual predicate and a failure message' do
       expect_offense(<<~RUBY)
         assert_predicate a, :valid?, "must be valid"


### PR DESCRIPTION
`RSpecRails/MinitestAssertions` built predicate matcher names from the predicate symbol source, so quoted symbols such as `:"valid?"` produced invalid autocorrection like `be_"valid?"`. The autocorrection now derives the matcher name from the symbol value and skips predicate symbols that cannot be converted to a safe matcher method name.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
