### PR TITLE
Add RSpecRails/NegationBeValid correction specs

### DIFF
--- a/spec/rubocop/cop/rspec_rails/negation_be_valid_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/negation_be_valid_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe RuboCop::Cop::RSpecRails::NegationBeValid do
         expect(foo).to be_invalid
                     ^^^^^^^^^^^^^ Use `expect(...).not_to be_valid`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        expect(foo).not_to be_valid
+      RUBY
+    end
+
+    it 'registers an offense when using ' \
+       '`is_expected.to be_invalid`' do
+      expect_offense(<<~RUBY)
+        is_expected.to be_invalid
+                    ^^^^^^^^^^^^^ Use `expect(...).not_to be_valid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        is_expected.not_to be_valid
+      RUBY
     end
 
     it 'does not register an offense when using ' \
@@ -46,6 +62,22 @@ RSpec.describe RuboCop::Cop::RSpecRails::NegationBeValid do
         expect(foo).not_to be_valid
                     ^^^^^^^^^^^^^^^ Use `expect(...).to be_invalid`.
       RUBY
+
+      expect_correction(<<~RUBY)
+        expect(foo).to be_invalid
+      RUBY
+    end
+
+    it 'registers an offense when using ' \
+       '`is_expected.not_to be_valid`' do
+      expect_offense(<<~RUBY)
+        is_expected.not_to be_valid
+                    ^^^^^^^^^^^^^^^ Use `expect(...).to be_invalid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        is_expected.to be_invalid
+      RUBY
     end
 
     it 'registers an offense when using ' \
@@ -53,6 +85,10 @@ RSpec.describe RuboCop::Cop::RSpecRails::NegationBeValid do
       expect_offense(<<~RUBY)
         expect(foo).to_not be_valid
                     ^^^^^^^^^^^^^^^ Use `expect(...).to be_invalid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(foo).to be_invalid
       RUBY
     end
 


### PR DESCRIPTION
`RSpecRails/NegationBeValid` already autocorrects the runner and matcher, but the specs only covered offense detection. This adds correction coverage for both enforced styles and explicit `is_expected` examples for the same conversions.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
