### PR TITLE
Add zizmor security audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: zizmor
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          annotations: true
+          min-confidence: high
+          version: v1.26.1


### PR DESCRIPTION
Add a zizmor security audit for GitHub Actions workflows.

The audit runs for pull requests and pushes to `master`, reports findings as annotations, and fails CI for high-confidence findings. This includes checking that SHA-pinned action references match their version comments through zizmor's `ref-version-mismatch` audit.

The workflow pins `zizmor-action` to `v0.5.7` and zizmor itself to `v1.26.1`. High-confidence findings are used as the initial blocking baseline because the existing workflows contain lower-confidence findings that should be addressed separately. A seven-day Dependabot cooldown is also added to satisfy zizmor's high-confidence supply-chain check.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests. Not applicable; this adds a CI workflow.
- [ ] Updated documentation. Not applicable; no documentation changed.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes. Not applicable; no code behavior changed.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
