### PR TITLE
Load cops lazily

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ Layout/LineLength:
   Max: 80 # default: 120
   AllowedPatterns:
     - '^\s*# .*https?:\/\/.+\[.+\]\.?$' # Allow long asciidoc links
+    - '^\s*register_cop :' # Cop registrations in the department module
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Speed up loading rubocop-rspec_rails by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
 - Fix offense message for `RSpecRails/HttpStatusNameConsistency` cop. ([@fatkodima])
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
 - Fix false positives for `RSpecRails/TravelAround` when travel does not directly wrap the around example. ([@ydah])
@@ -97,6 +98,7 @@
 [@fatkodima]: https://github.com/fatkodima
 [@g-rath]: https://github.com/G-Rath
 [@jojos003]: https://github.com/jojos003
+[@koic]: https://github.com/koic
 [@mothonmars]: https://github.com/MothOnMars
 [@mvz]: https://github.com/mvz
 [@nzlaura]: https://github.com/nzlaura

--- a/Rakefile
+++ b/Rakefile
@@ -98,9 +98,7 @@ task :new_cop, [:cop] do |_task, args|
   generator = RuboCop::RSpecRails::Cop::Generator.new(cop_name)
   generator.write_source
   generator.write_spec
-  generator.inject_require(
-    root_file_path: 'lib/rubocop/cop/rspec_rails_cops.rb'
-  )
+  generator.inject_registration
   generator.inject_config
 
   puts generator.todo

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -14,7 +14,7 @@ Use the bundled rake task `new_cop` to generate a cop template:
 $ bundle exec rake 'new_cop[RSpecRails/CopName]'
 [create] lib/rubocop/cop/rspec_rails/cop_name.rb
 [create] spec/rubocop/cop/rspec_rails/cop_name_spec.rb
-[modify] lib/rubocop/cop/rspec_rails_cops.rb - `require_relative 'rspec_rails/cop_name'` was injected.
+[modify] lib/rubocop/cop/rspec_rails.rb - `register_cop :CopName, "#{__dir__}/rspec_rails/cop_name"` was injected.
 [modify] A configuration for the cop is added into config/default.yml.
 Do 4 steps:
   1. Modify the description of RSpecRails/CopName in config/default.yml

--- a/lib/rubocop-rspec_rails.rb
+++ b/lib/rubocop-rspec_rails.rb
@@ -10,4 +10,4 @@ require_relative 'rubocop/rspec_rails/plugin'
 require_relative 'rubocop/rspec_rails/version'
 
 require 'rubocop/cop/rspec/base'
-require_relative 'rubocop/cop/rspec_rails_cops'
+require_relative 'rubocop/cop/rspec_rails'

--- a/lib/rubocop/cop/rspec_rails.rb
+++ b/lib/rubocop/cop/rspec_rails.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Cops for the `RSpecRails` department. The department's cops are
+    # registered for lazy loading and their files are loaded on demand.
+    module RSpecRails
+      extend LazyLoader
+
+      register_cop :AvoidSetupHook, "#{__dir__}/rspec_rails/avoid_setup_hook"
+      register_cop :HaveHttpStatus, "#{__dir__}/rspec_rails/have_http_status"
+      register_cop :HttpStatus, "#{__dir__}/rspec_rails/http_status"
+      register_cop :HttpStatusNameConsistency, "#{__dir__}/rspec_rails/http_status_name_consistency"
+      register_cop :InferredSpecType, "#{__dir__}/rspec_rails/inferred_spec_type"
+      register_cop :MinitestAssertions, "#{__dir__}/rspec_rails/minitest_assertions"
+      register_cop :NegationBeValid, "#{__dir__}/rspec_rails/negation_be_valid"
+      register_cop :ReceivePerformLater, "#{__dir__}/rspec_rails/receive_perform_later"
+      register_cop :TravelAround, "#{__dir__}/rspec_rails/travel_around"
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_rails_cops.rb
+++ b/lib/rubocop/cop/rspec_rails_cops.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'rspec_rails/avoid_setup_hook'
-require_relative 'rspec_rails/have_http_status'
-require_relative 'rspec_rails/http_status'
-require_relative 'rspec_rails/http_status_name_consistency'
-require_relative 'rspec_rails/inferred_spec_type'
-require_relative 'rspec_rails/minitest_assertions'
-require_relative 'rspec_rails/negation_be_valid'
-require_relative 'rspec_rails/receive_perform_later'
-require_relative 'rspec_rails/travel_around'
+# @deprecated This file is deprecated. Cops are registered for lazy loading in
+#   `rubocop/cop/rspec_rails`; this file is kept for compatibility with code
+#   that requires it directly.
+require_relative 'rspec_rails'

--- a/rubocop-rspec_rails.gemspec
+++ b/rubocop-rspec_rails.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '~> 1.72', '>= 1.72.1'
+  spec.add_dependency 'rubocop', '~> 1.89'
   spec.add_runtime_dependency 'rubocop-rspec', '~> 3.5'
 end

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe 'cop lazy loading' do
+  def run_script(source)
+    Dir.mktmpdir do |dir|
+      script = File.join(dir, 'script.rb')
+      File.write(script, source)
+      lib = File.expand_path('../../lib', __dir__)
+      output = `#{RbConfig.ruby} -I #{lib} #{script} 2>&1`
+      raise "script failed:\n#{output}" unless $CHILD_STATUS.success?
+
+      output
+    end
+  end
+
+  it 'registers every cop file in `lib/rubocop/cop/rspec_rails` exactly once' do
+    cop_root = File.expand_path('../../lib/rubocop/cop', __dir__)
+    files = Dir[File.join(cop_root, 'rspec_rails', '*.rb')].sort
+
+    department = RuboCop::Cop::Registry.global.cops_for_department(:RSpecRails)
+    registered = department.map do |cop|
+      Object.const_source_location(cop.name).first
+    end
+
+    expect(registered.sort).to eq(files)
+  end
+
+  it 'registers all cops without loading their files' do
+    output = run_script(<<~RUBY)
+      require 'rubocop-rspec_rails'
+
+      registry = RuboCop::Cop::Registry.global
+      loaded = $LOADED_FEATURES.grep(%r{/rubocop/cop/rspec_rails/})
+
+      puts "registered=\#{registry.names.grep(%r{\\ARSpecRails/}).size}"
+      puts "loaded_cop_files=\#{loaded.size}"
+    RUBY
+
+    expect(output).to include('registered=9', 'loaded_cop_files=0')
+  end
+
+  it 'does not register a cop twice when its file is required directly' do
+    output = run_script(<<~RUBY)
+      require 'rubocop-rspec_rails'
+
+      before = RuboCop::Cop::Registry.global.length
+      require 'rubocop/cop/rspec_rails/http_status'
+      after = RuboCop::Cop::Registry.global.length
+
+      puts "stable=\#{before == after}"
+      puts "class=\#{RuboCop::Cop::Registry.global.find_by_cop_name('RSpecRails/HttpStatus')}"
+    RUBY
+
+    expect(output).to include('stable=true', 'class=RuboCop::Cop::RSpecRails::HttpStatus')
+  end
+end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/15436.

Replace the 9 cop requires in `lib/rubocop/cop/rspec_rails_cops.rb` with an `RSpecRails` department module (`lib/rubocop/cop/rspec_rails.rb`) that registers every cop with the global registry through `RuboCop::Cop::LazyLoader#register_cop` without loading the cop files. A cop's file is loaded only when the cop class is needed, which for an inspection run means only the enabled cops. This follows the same mechanism RuboCop core adopted in rubocop/rubocop#15436 and requires RuboCop 1.89.0+.

The `register_cop` directives keep the former require order, because the registration order defines the cop execution order. The cross-gem `RuboCop::Cop::RSpec::Base` require stays eagerly in the gem entry point: `InferredSpecType` inherits from it when its file loads.

`lib/rubocop/cop/rspec_rails_cops.rb` is kept as a deprecated compatibility shim for code that requires it directly. The `new_cop` rake task switches from `inject_require` to `inject_registration`, and the development documentation is updated accordingly.

A new `spec/project/lazy_loading_spec.rb` requires every cop file in `lib/rubocop/cop/rspec_rails` to be registered exactly once and asserts the lazy behavior itself in subprocesses: no cop files loaded after `require 'rubocop-rspec_rails'`, and no double registration when a cop file is required directly.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
