### PR TITLE
Add new `RSpecRails/HardcodedAbsentRecordId` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Add new `RSpecRails/HardcodedAbsentRecordId` cop. ([@corsonknowles])
 - Speed up loading rubocop-rspec_rails by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
 - Fix offense message for `RSpecRails/HttpStatusNameConsistency` cop. ([@fatkodima])
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
@@ -93,6 +94,7 @@
 [@akiomik]: https://github.com/akiomik
 [@anthony-robin]: https://github.com/anthony-robin
 [@bquorning]: https://github.com/bquorning
+[@corsonknowles]: https://github.com/corsonknowles
 [@corydiamand]: https://github.com/corydiamand
 [@eugeneius]: https://github.com/eugeneius
 [@fatkodima]: https://github.com/fatkodima

--- a/config/default.yml
+++ b/config/default.yml
@@ -16,7 +16,7 @@ RSpecRails/HardcodedAbsentRecordId:
   Description: Checks for a hardcoded id standing in for an absent record.
   Enabled: pending
   AllowedNames: []
-  MaxId: 1000000
+  MaxId: 100000
   SafeAutoCorrect: false
   VersionAdded: '2.33'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HardcodedAbsentRecordId

--- a/config/default.yml
+++ b/config/default.yml
@@ -12,6 +12,15 @@ RSpecRails/AvoidSetupHook:
   VersionAdded: '2.4'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/AvoidSetupHook
 
+RSpecRails/HardcodedAbsentRecordId:
+  Description: Checks for a hardcoded id standing in for an absent record.
+  Enabled: pending
+  AllowedNames: []
+  MaxId: 1000000
+  SafeAutoCorrect: false
+  VersionAdded: '2.33'
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HardcodedAbsentRecordId
+
 RSpecRails/HaveHttpStatus:
   Description: Checks that tests use `have_http_status` instead of equality matchers.
   Enabled: pending

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -3,6 +3,7 @@
 === Department xref:cops_rspecrails.adoc[RSpecRails]
 
 * xref:cops_rspecrails.adoc#rspecrailsavoidsetuphook[RSpecRails/AvoidSetupHook]
+* xref:cops_rspecrails.adoc#rspecrailshardcodedabsentrecordid[RSpecRails/HardcodedAbsentRecordId]
 * xref:cops_rspecrails.adoc#rspecrailshavehttpstatus[RSpecRails/HaveHttpStatus]
 * xref:cops_rspecrails.adoc#rspecrailshttpstatus[RSpecRails/HttpStatus]
 * xref:cops_rspecrails.adoc#rspecrailshttpstatusnameconsistency[RSpecRails/HttpStatusNameConsistency]

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -42,6 +42,122 @@ end
 
 * https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/AvoidSetupHook
 
+[#rspecrailshardcodedabsentrecordid]
+== RSpecRails/HardcodedAbsentRecordId
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| Always (Unsafe)
+| 2.33
+| -
+|===
+
+Checks for a hardcoded id standing in for an absent record.
+
+Auto-increment climbs across every example in a run and is not
+reclaimed by transactional rollback, so the counter eventually
+reaches the literal. From then on a real row occupies it, the lookup
+succeeds, and the example stops testing absence -- passing locally,
+where the counter is low, and failing in CI. A negative id cannot
+collide, because auto-increment never emits one.
+
+An id counts as standing in for an absent record when its own example
+group either asserts absence (`ActiveRecord::RecordNotFound`, a
+`:not_found` response) or says so in its description. Both are read
+from the group the `let` is written in, not the whole file, so a
+shared id in an outer group is not attributed to a nested example
+that never uses it.
+
+In a list, a literal sitting beside a real `record.id` also qualifies
+on its own: you would write another `record.id` if you wanted one
+that exists.
+
+Not offenses: a group that builds a record carrying that id, a
+`RecordNotFound` raised by reloading a row the example just deleted,
+a literal above `MaxId`, and a group pinning two ids, which are
+usually pinned to differ from each other.
+
+[#safety-rspecrailshardcodedabsentrecordid]
+=== Safety
+
+Autocorrection is unsafe. `-1` is right for a primary key, but it
+also changes the value the example feeds to everything else, so an
+id matched against a stubbed request URI, a recorded cassette or an
+asserted error message needs those updated to match. Some codebases
+also reserve `-1` as a sentinel of their own, and an unsigned
+column rejects it outright.
+
+[#examples-rspecrailshardcodedabsentrecordid]
+=== Examples
+
+[source,ruby]
+----
+# bad
+context 'when the user does not exist' do
+  let(:user_id) { 123 }
+
+  it { expect { subject }.to raise_error(RecordNotFound) }
+end
+
+# bad - the literal is there precisely because no record has it
+let(:user_ids) { [user.id, other_user.id, 999_999] }
+
+# good - auto-increment never emits a negative id
+context 'when the user does not exist' do
+  let(:user_id) { -1 }
+
+  it { expect { subject }.to raise_error(RecordNotFound) }
+end
+
+# good - a deleted record's id is a reference, not a constant
+context 'when the user does not exist' do
+  let(:user_id) { deleted_user.id }
+end
+----
+
+[#allowednames_-__wise_id__-_default_-___-rspecrailshardcodedabsentrecordid]
+==== AllowedNames: ['wise_id'] (default: [])
+
+[source,ruby]
+----
+# good - a third-party identifier, not a primary key
+context 'when the transfer does not exist' do
+  let(:wise_id) { 5678 }
+end
+----
+
+[#maxid_-1000000-_default_-rspecrailshardcodedabsentrecordid]
+==== MaxId: 1000000 (default)
+
+[source,ruby]
+----
+# good - above MaxId the literal is a deliberate sentinel
+let(:user_id) { 9_999_999_999 }
+----
+
+[#configurable-attributes-rspecrailshardcodedabsentrecordid]
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedNames
+| `[]`
+| Array
+
+| MaxId
+| `1000000`
+| Integer
+|===
+
+[#references-rspecrailshardcodedabsentrecordid]
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HardcodedAbsentRecordId
+
 [#rspecrailshavehttpstatus]
 == RSpecRails/HaveHttpStatus
 

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -65,20 +65,25 @@ where the counter is low, and failing in CI. A negative id cannot
 collide, because auto-increment never emits one.
 
 An id counts as standing in for an absent record when its own example
-group either asserts absence (`ActiveRecord::RecordNotFound`, a
+group either expects absence (`ActiveRecord::RecordNotFound`, a
 `:not_found` response) or says so in its description. Both are read
 from the group the `let` is written in, not the whole file, so a
 shared id in an outer group is not attributed to a nested example
 that never uses it.
 
+The description has to name absence, not mismatch. A group saying the
+record belongs to someone else, or that an id is invalid, is about a
+row that exists.
+
 In a list, a literal sitting beside a real `record.id` also qualifies
 on its own: you would write another `record.id` if you wanted one
-that exists.
+that exists. A list only reads as record ids when every member is
+one, so `['story', '123', '']` is a format fixture and is skipped.
 
 Not offenses: a group that builds a record carrying that id, a
 `RecordNotFound` raised by reloading a row the example just deleted,
-a literal above `MaxId`, and a group pinning two ids, which are
-usually pinned to differ from each other.
+a literal above `MaxId`, and a group pinning two scalar ids, which
+are usually pinned to differ from each other.
 
 [#safety-rspecrailshardcodedabsentrecordid]
 === Safety
@@ -103,7 +108,7 @@ context 'when the user does not exist' do
 end
 
 # bad - the literal is there precisely because no record has it
-let(:user_ids) { [user.id, other_user.id, 999_999] }
+let(:user_ids) { [user.id, other_user.id, 99_999] }
 
 # good - auto-increment never emits a negative id
 context 'when the user does not exist' do
@@ -129,13 +134,15 @@ context 'when the transfer does not exist' do
 end
 ----
 
-[#maxid_-1000000-_default_-rspecrailshardcodedabsentrecordid]
-==== MaxId: 1000000 (default)
+[#maxid_-100000-_default_-rspecrailshardcodedabsentrecordid]
+==== MaxId: 100000 (default)
 
 [source,ruby]
 ----
 # good - above MaxId the literal is a deliberate sentinel
-let(:user_id) { 9_999_999_999 }
+context 'when the user does not exist' do
+  let(:user_id) { 999_999 }
+end
 ----
 
 [#configurable-attributes-rspecrailshardcodedabsentrecordid]
@@ -149,7 +156,7 @@ let(:user_id) { 9_999_999_999 }
 | Array
 
 | MaxId
-| `1000000`
+| `100000`
 | Integer
 |===
 

--- a/lib/rubocop/cop/rspec_rails.rb
+++ b/lib/rubocop/cop/rspec_rails.rb
@@ -8,6 +8,7 @@ module RuboCop
       extend LazyLoader
 
       register_cop :AvoidSetupHook, "#{__dir__}/rspec_rails/avoid_setup_hook"
+      register_cop :HardcodedAbsentRecordId, "#{__dir__}/rspec_rails/hardcoded_absent_record_id"
       register_cop :HaveHttpStatus, "#{__dir__}/rspec_rails/have_http_status"
       register_cop :HttpStatus, "#{__dir__}/rspec_rails/http_status"
       register_cop :HttpStatusNameConsistency, "#{__dir__}/rspec_rails/http_status_name_consistency"

--- a/lib/rubocop/cop/rspec_rails/hardcoded_absent_record_id.rb
+++ b/lib/rubocop/cop/rspec_rails/hardcoded_absent_record_id.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpecRails
+      # Checks for a hardcoded id standing in for an absent record.
+      #
+      # Auto-increment climbs across every example in a run and is not
+      # reclaimed by transactional rollback, so the counter eventually
+      # reaches the literal. From then on a real row occupies it, the lookup
+      # succeeds, and the example stops testing absence -- passing locally,
+      # where the counter is low, and failing in CI. A negative id cannot
+      # collide, because auto-increment never emits one.
+      #
+      # An id counts as standing in for an absent record when its own example
+      # group either asserts absence (`ActiveRecord::RecordNotFound`, a
+      # `:not_found` response) or says so in its description. Both are read
+      # from the group the `let` is written in, not the whole file, so a
+      # shared id in an outer group is not attributed to a nested example
+      # that never uses it.
+      #
+      # In a list, a literal sitting beside a real `record.id` also qualifies
+      # on its own: you would write another `record.id` if you wanted one
+      # that exists.
+      #
+      # Not offenses: a group that builds a record carrying that id, a
+      # `RecordNotFound` raised by reloading a row the example just deleted,
+      # a literal above `MaxId`, and a group pinning two ids, which are
+      # usually pinned to differ from each other.
+      #
+      # @safety
+      #   Autocorrection is unsafe. `-1` is right for a primary key, but it
+      #   also changes the value the example feeds to everything else, so an
+      #   id matched against a stubbed request URI, a recorded cassette or an
+      #   asserted error message needs those updated to match. Some codebases
+      #   also reserve `-1` as a sentinel of their own, and an unsigned
+      #   column rejects it outright.
+      #
+      # @example
+      #   # bad
+      #   context 'when the user does not exist' do
+      #     let(:user_id) { 123 }
+      #
+      #     it { expect { subject }.to raise_error(RecordNotFound) }
+      #   end
+      #
+      #   # bad - the literal is there precisely because no record has it
+      #   let(:user_ids) { [user.id, other_user.id, 999_999] }
+      #
+      #   # good - auto-increment never emits a negative id
+      #   context 'when the user does not exist' do
+      #     let(:user_id) { -1 }
+      #
+      #     it { expect { subject }.to raise_error(RecordNotFound) }
+      #   end
+      #
+      #   # good - a deleted record's id is a reference, not a constant
+      #   context 'when the user does not exist' do
+      #     let(:user_id) { deleted_user.id }
+      #   end
+      #
+      # @example AllowedNames: ['wise_id'] (default: [])
+      #   # good - a third-party identifier, not a primary key
+      #   context 'when the transfer does not exist' do
+      #     let(:wise_id) { 5678 }
+      #   end
+      #
+      # @example MaxId: 1000000 (default)
+      #   # good - above MaxId the literal is a deliberate sentinel
+      #   let(:user_id) { 9_999_999_999 }
+      #
+      class HardcodedAbsentRecordId < RuboCop::Cop::RSpec::Base
+        extend AutoCorrector
+
+        MSG = 'Use a negative id for a record expected to be absent.'
+        RESTRICT_ON_SEND = %i[let let!].freeze
+
+        # `id` itself, or any `<something>_id`, singular or plural.
+        ID_NAME = /\A(ids?|.+_ids?)\z/.freeze
+
+        # Each phrase is unambiguous on its own: a bare "missing" or
+        # "unknown" reads just as naturally about a header or a flag.
+        ABSENT_DESCRIPTION = /
+          (does|do|did)\s*n[o']?t\s+exist | \bnot\s+exist |
+          \bnot\s+found\b | (cannot|can\s*not|can't|couldn't)\s+be\s+found |
+          is\s*n[o']?t\s+found | non-?\s?existent | no\s+such |
+          invalid\s+\w*\s*\bid\b | \bid\b\s+is\s+invalid |
+          does\s*n[o']?t\s+belong | not\s+belong\s+to |
+          unauthorized\s+access |
+          (another|other|different)\s+
+            (account|company|customer|member|org|person|user)
+        /xi.freeze
+
+        NOT_FOUND = /RecordNotFound/.freeze
+        NOT_FOUND_STATUS = /\A:?(not_found|404)\z/.freeze
+        BUILDERS = %i[build build! build_list build_stubbed
+                      build_stubbed_list create create! create_list].freeze
+        DEFAULT_MAX_ID = 1_000_000
+
+        # @!method let_definition(node)
+        def_node_matcher :let_definition, <<~PATTERN
+          (any_block (send nil? {:let :let!} (sym $_) ...) _ $_)
+        PATTERN
+
+        def on_send(node)
+          name, body = node.parent && let_definition(node.parent)
+          return unless body && id_name?(name)
+          return if cassette_controlled?(node)
+
+          if body.array_type?
+            check_list(node, name, body)
+          else
+            check_literal(node, name, body)
+          end
+        end
+
+        private
+
+        # A third-party identifier stored in a `*_id` field is not a primary
+        # key the counter can reach, so a name in `AllowedNames` is skipped --
+        # a named exception in config beats a path exclude or a disable.
+        def id_name?(name)
+          name.to_s.match?(ID_NAME) &&
+            !Array(cop_config['AllowedNames']).include?(name.to_s)
+        end
+
+        def check_literal(node, name, literal)
+          value = collidable_id(literal)
+          group = value && enclosing_example_group(node)
+          return unless group && absent_context?(group)
+          return if built_with?(group, name, value) || paired_ids?(group)
+
+          register(literal)
+        end
+
+        # Only a lone literal qualifies. Two would both correct to `-1`, and
+        # a duplicated id collapses on lookup, changing the asserted count.
+        def check_list(node, name, array)
+          literals = array.children.select { |item| collidable_id(item) }
+          return unless literals.one?
+
+          group = enclosing_example_group(node)
+          return unless list_qualifies?(array, group)
+
+          literal = literals.first
+          return if group && built_with?(group, name, collidable_id(literal))
+
+          register(literal)
+        end
+
+        def list_qualifies?(array, group)
+          real_id = array.children.any? { |i| i.send_type? && i.method?(:id) }
+          real_id || (!group.nil? && absent_context?(group))
+        end
+
+        def register(literal)
+          add_offense(literal) do |corrector|
+            corrector.replace(literal, literal.str_type? ? "'-1'" : '-1')
+          end
+        end
+
+        def collidable_id(node)
+          CollidableId.in(node, max_id)
+        end
+
+        def max_id
+          cop_config.fetch('MaxId', DEFAULT_MAX_ID)
+        end
+
+        def enclosing_example_group(node)
+          node.each_ancestor(:any_block).find { |a| example_group?(a) }
+        end
+
+        def absent_context?(group)
+          inspect_group(group).absent?
+        end
+
+        def built_with?(group, name, value)
+          inspect_group(group).builds?(name, value)
+        end
+
+        def paired_ids?(group)
+          inspect_group(group).paired_ids?
+        end
+
+        def inspect_group(group)
+          GroupInspector.new(group, max_id)
+        end
+
+        # A cassette keys its recorded interactions off the request URI, so
+        # an id in the path is what tells two same-route requests apart.
+        # Rewriting it makes the example miss the recording.
+        def cassette_controlled?(node)
+          node.each_ancestor(:any_block).any? do |ancestor|
+            example_group?(ancestor) &&
+              ancestor.send_node.arguments.any? { |argument| vcr?(argument) }
+          end
+        end
+
+        def vcr?(argument)
+          return true if argument.sym_type? && argument.value == :vcr
+          return false unless argument.hash_type?
+
+          argument.pairs.any? do |pair|
+            pair.key.type?(:sym, :str) && pair.key.value.to_s == 'vcr'
+          end
+        end
+
+        # A string id reaches the same column as an integer one, so both
+        # count; only the sign and the magnitude matter.
+        module CollidableId
+          def self.in(node, max_id)
+            value = case node.type
+                    when :int then node.value
+                    when :str then Integer(node.value, exception: false)
+                    end
+            value if value&.positive? && value <= max_id
+          end
+        end
+
+        # Answers the group-level questions: does this group say the record
+        # is absent, does it build the record, and does it pin two ids?
+        class GroupInspector
+          include RuboCop::RSpec::Language
+          extend RuboCop::AST::NodePattern::Macros
+
+          # @!method let_definition(node)
+          def_node_matcher :let_definition, <<~PATTERN
+            (any_block (send nil? {:let :let!} (sym $_) ...) _ $_)
+          PATTERN
+
+          def initialize(group, max_id)
+            @group = group
+            @max_id = max_id
+          end
+
+          def absent?
+            absent_description? || not_found_assertion?(group.body)
+          end
+
+          # A group that builds a record carrying this id means the row is
+          # meant to exist, so its absence is about something else.
+          def builds?(name, value)
+            group.each_descendant(:send).any? do |send_node|
+              BUILDERS.include?(send_node.method_name) &&
+                send_node.each_descendant.any? do |argument|
+                  references?(argument, name) || same_id_value?(argument, value)
+                end
+            end
+          end
+
+          # Two ids pinned in one group are usually pinned to differ from
+          # each other -- a record and the "other user" it must not match.
+          # One shared replacement collapses that and inverts the example.
+          def paired_ids?
+            own_lets(group.body).count { |_n, body| collidable_id(body) } > 1
+          end
+
+          private
+
+          attr_reader :group, :max_id
+
+          def collidable_id(node)
+            CollidableId.in(node, max_id)
+          end
+
+          def references?(node, name)
+            node.send_type? && node.receiver.nil? && node.method?(name)
+          end
+
+          # `create(:user, account_id: 1)` beside `let(:account_id) { 1 }`
+          # builds the row this id selects, even when the literal is inlined.
+          def same_id_value?(node, value)
+            node.pair_type? && node.key.type?(:sym, :str) &&
+              node.key.value.to_s.match?(ID_NAME) &&
+              collidable_id(node.value) == value
+          end
+
+          def own_lets(node, found = [])
+            return found if node.type?(:any_block) && example_group?(node)
+
+            definition = let_definition(node)
+            body = definition&.last
+            found << definition if body && !body.array_type?
+            node.each_child_node { |child| own_lets(child, found) }
+            found
+          end
+
+          # Matched against the source so an interpolated description
+          # ("when #{model} does not exist") still reads as one.
+          def absent_description?
+            description = group.send_node.first_argument
+            return false unless description&.type?(:str, :dstr, :sym)
+
+            ABSENT_DESCRIPTION.match?(description.source)
+          end
+
+          # Scoped to this group: the walk stops at a nested example group,
+          # whose assertions belong to whatever that group redefines.
+          def not_found_assertion?(node)
+            return false if node.type?(:any_block) && example_group?(node)
+            return true if node.send_type? && not_found_matcher?(node)
+
+            node.each_child_node.any? { |child| not_found_assertion?(child) }
+          end
+
+          def not_found_matcher?(node)
+            case node.method_name
+            when :raise_error, :raise_exception
+              node.arguments.any? { |arg| NOT_FOUND.match?(arg.source) } &&
+                !deleted_record_assertion?(node)
+            when :have_http_status
+              NOT_FOUND_STATUS.match?(node.first_argument&.source.to_s)
+            when :be_not_found then true
+            else false
+            end
+          end
+
+          # `expect { record.reload }.to raise_error(RecordNotFound)` asserts
+          # that a row the example already holds was deleted by the code under
+          # test. That is about the object, not about the literal -- which is
+          # usually what selected the row for deletion in the first place.
+          def deleted_record_assertion?(node)
+            subject = node.each_ancestor(:send).first&.receiver
+            return false unless subject&.type?(:any_block)
+
+            subject.body&.send_type? && subject.body.method?(:reload)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_rails/hardcoded_absent_record_id.rb
+++ b/lib/rubocop/cop/rspec_rails/hardcoded_absent_record_id.rb
@@ -13,20 +13,25 @@ module RuboCop
       # collide, because auto-increment never emits one.
       #
       # An id counts as standing in for an absent record when its own example
-      # group either asserts absence (`ActiveRecord::RecordNotFound`, a
+      # group either expects absence (`ActiveRecord::RecordNotFound`, a
       # `:not_found` response) or says so in its description. Both are read
       # from the group the `let` is written in, not the whole file, so a
       # shared id in an outer group is not attributed to a nested example
       # that never uses it.
       #
+      # The description has to name absence, not mismatch. A group saying the
+      # record belongs to someone else, or that an id is invalid, is about a
+      # row that exists.
+      #
       # In a list, a literal sitting beside a real `record.id` also qualifies
       # on its own: you would write another `record.id` if you wanted one
-      # that exists.
+      # that exists. A list only reads as record ids when every member is
+      # one, so `['story', '123', '']` is a format fixture and is skipped.
       #
       # Not offenses: a group that builds a record carrying that id, a
       # `RecordNotFound` raised by reloading a row the example just deleted,
-      # a literal above `MaxId`, and a group pinning two ids, which are
-      # usually pinned to differ from each other.
+      # a literal above `MaxId`, and a group pinning two scalar ids, which
+      # are usually pinned to differ from each other.
       #
       # @safety
       #   Autocorrection is unsafe. `-1` is right for a primary key, but it
@@ -45,7 +50,7 @@ module RuboCop
       #   end
       #
       #   # bad - the literal is there precisely because no record has it
-      #   let(:user_ids) { [user.id, other_user.id, 999_999] }
+      #   let(:user_ids) { [user.id, other_user.id, 99_999] }
       #
       #   # good - auto-increment never emits a negative id
       #   context 'when the user does not exist' do
@@ -65,9 +70,11 @@ module RuboCop
       #     let(:wise_id) { 5678 }
       #   end
       #
-      # @example MaxId: 1000000 (default)
+      # @example MaxId: 100000 (default)
       #   # good - above MaxId the literal is a deliberate sentinel
-      #   let(:user_id) { 9_999_999_999 }
+      #   context 'when the user does not exist' do
+      #     let(:user_id) { 999_999 }
+      #   end
       #
       class HardcodedAbsentRecordId < RuboCop::Cop::RSpec::Base
         extend AutoCorrector
@@ -78,24 +85,18 @@ module RuboCop
         # `id` itself, or any `<something>_id`, singular or plural.
         ID_NAME = /\A(ids?|.+_ids?)\z/.freeze
 
-        # Each phrase is unambiguous on its own: a bare "missing" or
-        # "unknown" reads just as naturally about a header or a flag.
+        # Only wording that names absence. "Invalid", "does not belong" and
+        # "unauthorized" describe a row that exists and is the wrong one,
+        # which is a different example and a different fix.
         ABSENT_DESCRIPTION = /
           (does|do|did)\s*n[o']?t\s+exist | \bnot\s+exist |
           \bnot\s+found\b | (cannot|can\s*not|can't|couldn't)\s+be\s+found |
-          is\s*n[o']?t\s+found | non-?\s?existent | no\s+such |
-          invalid\s+\w*\s*\bid\b | \bid\b\s+is\s+invalid |
-          does\s*n[o']?t\s+belong | not\s+belong\s+to |
-          unauthorized\s+access |
-          (another|other|different)\s+
-            (account|company|customer|member|org|person|user)
+          is\s*n[o']?t\s+found | non-?\s?existent | no\s+such
         /xi.freeze
 
         NOT_FOUND = /RecordNotFound/.freeze
         NOT_FOUND_STATUS = /\A:?(not_found|404)\z/.freeze
-        BUILDERS = %i[build build! build_list build_stubbed
-                      build_stubbed_list create create! create_list].freeze
-        DEFAULT_MAX_ID = 1_000_000
+        DEFAULT_MAX_ID = 100_000
 
         # @!method let_definition(node)
         def_node_matcher :let_definition, <<~PATTERN
@@ -133,19 +134,33 @@ module RuboCop
           register(literal)
         end
 
-        # Only a lone literal qualifies. Two would both correct to `-1`, and
-        # a duplicated id collapses on lookup, changing the asserted count.
         def check_list(node, name, array)
+          return if format_fixture?(array)
+
           literals = array.children.select { |item| collidable_id(item) }
-          return unless literals.one?
-
           group = enclosing_example_group(node)
-          return unless list_qualifies?(array, group)
+          return if literals.empty? || !list_qualifies?(array, group)
 
-          literal = literals.first
-          return if group && built_with?(group, name, collidable_id(literal))
+          register_list(literals, group, name)
+        end
 
-          register(literal)
+        # Each literal gets its own negative: a duplicated id collapses on
+        # lookup, which would change the count the example asserts.
+        def register_list(literals, group, name)
+          literals.each_with_index do |literal, index|
+            next if group && built_with?(group, name, collidable_id(literal))
+
+            register(literal, -(index + 1))
+          end
+        end
+
+        # `['story', 'story-', '123', '']` lists the shapes an id parser has
+        # to reject, so its numeric member is a format, not a primary key.
+        def format_fixture?(array)
+          array.children.any? do |item|
+            item.type?(:str, :sym) &&
+              Integer(item.value.to_s, exception: false).nil?
+          end
         end
 
         def list_qualifies?(array, group)
@@ -153,10 +168,10 @@ module RuboCop
           real_id || (!group.nil? && absent_context?(group))
         end
 
-        def register(literal)
-          add_offense(literal) do |corrector|
-            corrector.replace(literal, literal.str_type? ? "'-1'" : '-1')
-          end
+        def register(literal, replacement = -1)
+          negative = replacement.to_s
+          negative = "'#{negative}'" if literal.str_type?
+          add_offense(literal) { |corr| corr.replace(literal, negative) }
         end
 
         def collidable_id(node)
@@ -229,23 +244,30 @@ module RuboCop
             (any_block (send nil? {:let :let!} (sym $_) ...) _ $_)
           PATTERN
 
+          # @!method builder_calls(node)
+          def_node_search :builder_calls, <<~PATTERN
+            $(send _ {:build :build! :build_list :build_pair :build_stubbed
+                      :build_stubbed_list :create :create! :create_list
+                      :create_pair} ...)
+          PATTERN
+
           def initialize(group, max_id)
             @group = group
             @max_id = max_id
           end
 
           def absent?
-            absent_description? || not_found_assertion?(group.body)
+            absent_description? || not_found_expectation?(group.body)
           end
 
           # A group that builds a record carrying this id means the row is
           # meant to exist, so its absence is about something else.
           def builds?(name, value)
-            group.each_descendant(:send).any? do |send_node|
-              BUILDERS.include?(send_node.method_name) &&
-                send_node.each_descendant.any? do |argument|
-                  references?(argument, name) || same_id_value?(argument, value)
-                end
+            builder_calls(group).any? do |call|
+              factory = factory_name(call)
+              call.each_descendant(:send, :pair).any? do |node|
+                references?(node, name) || own_attribute?(node, factory, value)
+              end
             end
           end
 
@@ -268,12 +290,26 @@ module RuboCop
             node.send_type? && node.receiver.nil? && node.method?(name)
           end
 
-          # `create(:user, account_id: 1)` beside `let(:account_id) { 1 }`
-          # builds the row this id selects, even when the literal is inlined.
-          def same_id_value?(node, value)
-            node.pair_type? && node.key.type?(:sym, :str) &&
-              node.key.value.to_s.match?(ID_NAME) &&
-              collidable_id(node.value) == value
+          def factory_name(call)
+            first_argument = call.first_argument
+            first_argument.value.to_s if first_argument&.sym_type?
+          end
+
+          # The built record carries the id when the key is its own primary
+          # key, or when the attribute is named for the factory, as in
+          # `create(:card, corepro_card_id: 123)`. A key naming another
+          # table is a foreign key: `create(:user, account_id: 1)` points at
+          # the accounts row the example says is absent rather than creating
+          # it, so it is not treated as building it.
+          def own_attribute?(node, factory, value)
+            return false unless node.pair_type? &&
+              node.key.type?(:sym, :str)
+
+            key = node.key.value.to_s
+            return false unless key.match?(ID_NAME)
+            return false unless collidable_id(node.value) == value
+
+            key == 'id' || (!factory.nil? && key.include?(factory))
           end
 
           def own_lets(node, found = [])
@@ -296,19 +332,19 @@ module RuboCop
           end
 
           # Scoped to this group: the walk stops at a nested example group,
-          # whose assertions belong to whatever that group redefines.
-          def not_found_assertion?(node)
+          # whose expectations belong to whatever that group redefines.
+          def not_found_expectation?(node)
             return false if node.type?(:any_block) && example_group?(node)
             return true if node.send_type? && not_found_matcher?(node)
 
-            node.each_child_node.any? { |child| not_found_assertion?(child) }
+            node.each_child_node.any? { |child| not_found_expectation?(child) }
           end
 
           def not_found_matcher?(node)
             case node.method_name
             when :raise_error, :raise_exception
               node.arguments.any? { |arg| NOT_FOUND.match?(arg.source) } &&
-                !deleted_record_assertion?(node)
+                !deleted_record_expectation?(node)
             when :have_http_status
               NOT_FOUND_STATUS.match?(node.first_argument&.source.to_s)
             when :be_not_found then true
@@ -316,11 +352,11 @@ module RuboCop
             end
           end
 
-          # `expect { record.reload }.to raise_error(RecordNotFound)` asserts
+          # `expect { record.reload }.to raise_error(RecordNotFound)` expects
           # that a row the example already holds was deleted by the code under
           # test. That is about the object, not about the literal -- which is
           # usually what selected the row for deletion in the first place.
-          def deleted_record_assertion?(node)
+          def deleted_record_expectation?(node)
             subject = node.each_ancestor(:send).first&.receiver
             return false unless subject&.type?(:any_block)
 

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'cop lazy loading' do
       puts "loaded_cop_files=\#{loaded.size}"
     RUBY
 
-    expect(output).to include('registered=9', 'loaded_cop_files=0')
+    expect(output).to include('registered=10', 'loaded_cop_files=0')
   end
 
   it 'does not register a cop twice when its file is required directly' do

--- a/spec/rubocop/cop/rspec_rails/hardcoded_absent_record_id_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/hardcoded_absent_record_id_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
-  let(:cop_config) { { 'MaxId' => 1_000_000 } }
+  let(:cop_config) { { 'MaxId' => 100_000 } }
 
   it 'registers an offense when a group says the record does not exist' do
     expect_offense(<<~RUBY)
@@ -106,11 +106,26 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
     RUBY
   end
 
-  it 'registers an offense for a cross-tenant description' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense for a cross-tenant description' do
+    expect_no_offenses(<<~RUBY)
       context 'for another account' do
         let(:requested_account_id) { 2 }
-                                     ^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a mismatch description' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the commit does not belong to the merge request' do
+        let(:parent_ids) { [1] }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a malformed-id description' do
+    expect_no_offenses(<<~RUBY)
+      context 'with invalid id' do
+        let(:invalid_id) { 123 }
       end
     RUBY
   end
@@ -169,8 +184,8 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
   it 'registers an offense for a lone literal beside real record ids' do
     expect_offense(<<~RUBY)
       context 'with multiple user IDs' do
-        let(:user_ids) { [user.id, other_user.id, 999999] }
-                                                  ^^^^^^ Use a negative id for a record expected to be absent.
+        let(:user_ids) { [user.id, other_user.id, 99999] }
+                                                  ^^^^^ Use a negative id for a record expected to be absent.
       end
     RUBY
 
@@ -193,8 +208,8 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
   it 'registers an offense for a list the group calls absent' do
     expect_offense(<<~RUBY)
       context 'when the user does not exist' do
-        let(:user_ids) { [999999] }
-                          ^^^^^^ Use a negative id for a record expected to be absent.
+        let(:user_ids) { [99999] }
+                          ^^^^^ Use a negative id for a record expected to be absent.
       end
     RUBY
   end
@@ -383,7 +398,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
 
   it 'does not register an offense when the literal is inlined' do
     expect_no_offenses(<<~RUBY)
-      describe 'unauthorized access' do
+      describe 'when the user does not exist' do
         let(:user_id) { 2 }
 
         before { create(:user, id: 2) }
@@ -419,6 +434,69 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
                         ^ Use a negative id for a record expected to be absent.
 
         before { create(:user, user_id: 3) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the built record carries it' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the card does not exist' do
+        let(:card_id) { 123 }
+
+        before { create(:card, corepro_card_id: 123) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the builder only points at the id' do
+    expect_offense(<<~RUBY)
+      context 'when the account does not exist' do
+        let(:account_id) { 1 }
+                           ^ Use a negative id for a record expected to be absent.
+
+        before { create(:user, account_id: 1) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a receiver builder points at the id' do
+    expect_offense(<<~RUBY)
+      context 'when the account does not exist' do
+        let(:account_id) { 2 }
+                           ^ Use a negative id for a record expected to be absent.
+
+        before { User.create!(account_id: 2) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a receiver builder carries it' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 2 }
+
+        before { User.create!(id: 2) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a builder takes no arguments' do
+    expect_offense(<<~RUBY)
+      context 'when the account does not exist' do
+        let(:account_id) { 1 }
+                           ^ Use a negative id for a record expected to be absent.
+
+        before { described_class.create }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when `create_pair` builds that id' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 123 }
+
+        before { create_pair(:user, id: 123) }
       end
     RUBY
   end
@@ -479,7 +557,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
 
   it 'does not register an offense for a group pinning two ids' do
     expect_no_offenses(<<~RUBY)
-      context 'for a different account' do
+      context 'when the account does not exist' do
         let(:account_id) { 456 }
         let(:existing_setting_account_id) { 123 }
       end
@@ -488,7 +566,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
 
   it 'registers an offense for a lone id beside a non-collidable one' do
     expect_offense(<<~RUBY)
-      context 'for a different account' do
+      context 'when the account does not exist' do
         let(:account_id) { 456 }
                            ^^^ Use a negative id for a record expected to be absent.
         let(:existing_setting_account_id) { -1 }
@@ -518,10 +596,26 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
     RUBY
   end
 
-  it 'does not register an offense for a list holding two literals' do
-    expect_no_offenses(<<~RUBY)
+  it 'registers an offense per literal in a list, corrected to differ' do
+    expect_offense(<<~RUBY)
       context 'when the users do not exist' do
         let(:user_ids) { [user.id, 999, 1000] }
+                                   ^^^ Use a negative id for a record expected to be absent.
+                                        ^^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      context 'when the users do not exist' do
+        let(:user_ids) { [user.id, -1, -2] }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a format-validation list' do
+    expect_no_offenses(<<~RUBY)
+      context 'with several ids' do
+        let(:invalid_ids) { ['story', 'story-', '-', '123', ''] }
       end
     RUBY
   end
@@ -556,7 +650,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
     expect_no_offenses(<<~RUBY)
       RSpec.describe Controller, vcr: { cassette_name: 'x', match_requests_on: [:method, :uri] } do
         context 'when the user does not exist' do
-          let(:user_id) { 111111 }
+          let(:user_id) { 11111 }
         end
       end
     RUBY
@@ -566,7 +660,7 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
     expect_no_offenses(<<~RUBY)
       RSpec.describe Controller, :vcr do
         context 'when the user does not exist' do
-          let(:user_id) { 111111 }
+          let(:user_id) { 11111 }
         end
       end
     RUBY
@@ -576,8 +670,8 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
     expect_offense(<<~RUBY)
       RSpec.describe Controller, :request, other: { a: 1 } do
         context 'when the user does not exist' do
-          let(:user_id) { 111111 }
-                          ^^^^^^ Use a negative id for a record expected to be absent.
+          let(:user_id) { 11111 }
+                          ^^^^^ Use a negative id for a record expected to be absent.
         end
       end
     RUBY
@@ -587,8 +681,8 @@ RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
     expect_offense(<<~RUBY)
       RSpec.describe Controller, some_key => 1 do
         context 'when the user does not exist' do
-          let(:user_id) { 111111 }
-                          ^^^^^^ Use a negative id for a record expected to be absent.
+          let(:user_id) { 11111 }
+                          ^^^^^ Use a negative id for a record expected to be absent.
         end
       end
     RUBY

--- a/spec/rubocop/cop/rspec_rails/hardcoded_absent_record_id_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/hardcoded_absent_record_id_spec.rb
@@ -1,0 +1,675 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpecRails::HardcodedAbsentRecordId do
+  let(:cop_config) { { 'MaxId' => 1_000_000 } }
+
+  it 'registers an offense when a group says the record does not exist' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { -1 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for `let!`' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let!(:user_id) { 123 }
+                         ^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a bare `id`' do
+    expect_offense(<<~RUBY)
+      context 'when the record is not found' do
+        let(:id) { 7 }
+                   ^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a numeric string and keeps it a string' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { '123' }
+                        ^^^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { '-1' }
+      end
+    RUBY
+  end
+
+  it 'registers an offense on a `RecordNotFound` assertion alone' do
+    expect_offense(<<~RUBY)
+      context 'and the state is success' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+
+        it { expect { subject }.to raise_error ActiveRecord::RecordNotFound }
+      end
+    RUBY
+  end
+
+  it 'registers an offense on a `raise_exception` assertion' do
+    expect_offense(<<~RUBY)
+      context 'and the state is success' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+
+        it { expect { subject }.to raise_exception(ActiveRecord::RecordNotFound) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense on a `:not_found` response assertion' do
+    expect_offense(<<~RUBY)
+      context 'with an id that was deleted' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+
+        it { expect(response).to have_http_status(:not_found) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense on a numeric 404 assertion' do
+    expect_offense(<<~RUBY)
+      context 'with an id that was deleted' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+
+        it { expect(response).to have_http_status(404) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense on a `be_not_found` assertion' do
+    expect_offense(<<~RUBY)
+      context 'with an id that was deleted' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+
+        it { expect(response).to be_not_found }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a cross-tenant description' do
+    expect_offense(<<~RUBY)
+      context 'for another account' do
+        let(:requested_account_id) { 2 }
+                                     ^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a symbol description' do
+    expect_offense(<<~RUBY)
+      context :'when the user does not exist' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for an interpolated description' do
+    expect_offense(<<~'RUBY')
+      context "when the #{model} does not exist" do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'registers an offense inside a nested non-group block' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        with_some_wrapper do
+          let(:user_id) { 123 }
+                          ^^^ Use a negative id for a record expected to be absent.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense inside a group written on RSpec explicitly' do
+    expect_offense(<<~RUBY)
+      RSpec.describe 'when the user does not exist' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'attributes the assertion to the innermost group' do
+    expect_offense(<<~RUBY)
+      context 'outer' do
+        let(:outer_id) { 500 }
+
+        context 'when the user does not exist' do
+          let(:user_id) { 123 }
+                          ^^^ Use a negative id for a record expected to be absent.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a lone literal beside real record ids' do
+    expect_offense(<<~RUBY)
+      context 'with multiple user IDs' do
+        let(:user_ids) { [user.id, other_user.id, 999999] }
+                                                  ^^^^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      context 'with multiple user IDs' do
+        let(:user_ids) { [user.id, other_user.id, -1] }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a literal anywhere in the list' do
+    expect_offense(<<~RUBY)
+      context 'with multiple users provided' do
+        let(:user_ids) { [999, user.id] }
+                          ^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a list the group calls absent' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_ids) { [999999] }
+                          ^^^^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a plural id bound to a scalar' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_ids) { 999 }
+                         ^^^ Use a negative id for a record expected to be absent.
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a negative id' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { -1 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a zero id' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 0 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense above MaxId' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 9_999_999_999 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a let that is not id-named' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:identifier) { 123 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a non-symbol let name' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let('user_id') { 123 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a reference' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { deleted_user.id }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a non-numeric string' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 'abc' }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a non-literal body type' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 1.5 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for an empty let body' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) {}
+      end
+    RUBY
+  end
+
+  it 'does not register an offense outside any example group' do
+    expect_no_offenses(<<~RUBY)
+      let(:user_id) { 123 }
+    RUBY
+  end
+
+  it 'does not register an offense when the description is a constant' do
+    expect_no_offenses(<<~RUBY)
+      describe User do
+        let(:user_id) { 123 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a neutral interpolation' do
+    expect_no_offenses(<<~'RUBY')
+      context "when #{thing} is here" do
+        let(:user_id) { 123 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense without any absence signal' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user is suspended' do
+        let(:user_id) { 123 }
+
+        it { expect(response).to have_http_status(:ok) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for an unrelated error class' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user is suspended' do
+        let(:user_id) { 123 }
+
+        it { expect { subject }.to raise_error ArgumentError }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a bare `raise_error`' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user is suspended' do
+        let(:user_id) { 123 }
+
+        it { expect { subject }.to raise_error }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for `have_http_status` with no argument' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user is suspended' do
+        let(:user_id) { 123 }
+
+        it { expect(response).to have_http_status }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a forbidden response alone' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the signature header is invalid' do
+        let(:external_payout_id) { 12345 }
+
+        it { expect(response).to have_http_status(:forbidden) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for an ambiguous "missing" description' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the signature header is missing' do
+        let(:external_payout_id) { 12345 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the group builds that id' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the cached data does not exist for the card' do
+        let(:card_id) { 123 }
+        let!(:card) { create(:card, external_card_id: card_id) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a nested group builds it' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the cached data does not exist for the card' do
+        let(:card_id) { 123 }
+
+        context 'and the card exists' do
+          let!(:card) { build_stubbed(:card, external_card_id: card_id) }
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the literal is inlined' do
+    expect_no_offenses(<<~RUBY)
+      describe 'unauthorized access' do
+        let(:user_id) { 2 }
+
+        before { create(:user, id: 2) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the builder references a different id' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+        let!(:card) { create(:card, owner_id: other_id) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the key is not id-like' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 2 }
+                        ^ Use a negative id for a record expected to be absent.
+
+        before { create(:user, headcount: 2) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the builder carries a different id value' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 2 }
+                        ^ Use a negative id for a record expected to be absent.
+
+        before { create(:user, user_id: 3) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the builder hash has a non-literal key' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 2 }
+                        ^ Use a negative id for a record expected to be absent.
+
+        before { create(:user, attribute => 2) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a reload assertion' do
+    expect_no_offenses(<<~RUBY)
+      describe 'the delete task' do
+        let(:user_id) { 1 }
+
+        it { expect { record.reload }.to raise_error(ActiveRecord::RecordNotFound) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the matcher subject is not a block' do
+    expect_offense(<<~RUBY)
+      describe 'the delete task' do
+        let(:user_id) { 1 }
+                        ^ Use a negative id for a record expected to be absent.
+
+        it { expect(result).to raise_error(ActiveRecord::RecordNotFound) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the expect block is empty' do
+    expect_offense(<<~RUBY)
+      describe 'the delete task' do
+        let(:user_id) { 1 }
+                        ^ Use a negative id for a record expected to be absent.
+
+        it { expect {}.to raise_error(ActiveRecord::RecordNotFound) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a bare matcher with no surrounding call' do
+    expect_offense(<<~RUBY)
+      describe 'the delete task' do
+        let(:user_id) { 1 }
+                        ^ Use a negative id for a record expected to be absent.
+
+        it { raise_error(ActiveRecord::RecordNotFound) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a group pinning two ids' do
+    expect_no_offenses(<<~RUBY)
+      context 'for a different account' do
+        let(:account_id) { 456 }
+        let(:existing_setting_account_id) { 123 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a lone id beside a non-collidable one' do
+    expect_offense(<<~RUBY)
+      context 'for a different account' do
+        let(:account_id) { 456 }
+                           ^^^ Use a negative id for a record expected to be absent.
+        let(:existing_setting_account_id) { -1 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a lone id beside an id in a nested group' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 456 }
+                        ^^^ Use a negative id for a record expected to be absent.
+
+        context 'and the record is not found' do
+          let(:other_id) { 123 }
+                           ^^^ Use a negative id for a record expected to be absent.
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a list with neither signal' do
+    expect_no_offenses(<<~RUBY)
+      context 'with several users' do
+        let(:user_ids) { [999] }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a list holding two literals' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the users do not exist' do
+        let(:user_ids) { [user.id, 999, 1000] }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a list of only real record ids' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_ids) { [user.id, other_user.id] }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a list whose literal is above MaxId' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_ids) { [user.id, 9999999999] }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when a list literal is built' do
+    expect_no_offenses(<<~RUBY)
+      context 'with multiple users' do
+        let(:user_ids) { [user.id, 999] }
+
+        before { create(:user, id: 999) }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense under a VCR cassette' do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Controller, vcr: { cassette_name: 'x', match_requests_on: [:method, :uri] } do
+        context 'when the user does not exist' do
+          let(:user_id) { 111111 }
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense under bare `:vcr` metadata' do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Controller, :vcr do
+        context 'when the user does not exist' do
+          let(:user_id) { 111111 }
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense under non-VCR metadata' do
+    expect_offense(<<~RUBY)
+      RSpec.describe Controller, :request, other: { a: 1 } do
+        context 'when the user does not exist' do
+          let(:user_id) { 111111 }
+                          ^^^^^^ Use a negative id for a record expected to be absent.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when group metadata has a non-literal key' do
+    expect_offense(<<~RUBY)
+      RSpec.describe Controller, some_key => 1 do
+        context 'when the user does not exist' do
+          let(:user_id) { 111111 }
+                          ^^^^^^ Use a negative id for a record expected to be absent.
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense beside a let with a non-symbol name' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+        let('other') { 5 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for a block-pass let outside any group' do
+    expect_no_offenses(<<~RUBY)
+      let(:user_id, &builder)
+    RUBY
+  end
+
+  it 'does not register an offense for a let with no name' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let { 123 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when the group has no description' do
+    expect_no_offenses(<<~RUBY)
+      describe do
+        let(:user_id) { 123 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense beside a let with an empty body' do
+    expect_offense(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id) { 123 }
+                        ^^^ Use a negative id for a record expected to be absent.
+        let(:other_id) {}
+      end
+    RUBY
+  end
+
+  context 'with AllowedNames' do
+    let(:cop_config) { { 'AllowedNames' => ['wise_id'] } }
+
+    it 'does not register an offense for an allowed field name' do
+      expect_no_offenses(<<~RUBY)
+        context 'when the transfer does not exist' do
+          let(:wise_id) { 5678 }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for an allowed name in a list' do
+      expect_no_offenses(<<~RUBY)
+        context 'when the transfer does not exist' do
+          let(:wise_id) { [transfer.id, 5678] }
+        end
+      RUBY
+    end
+
+    it 'still registers an offense for a name that is not allowed' do
+      expect_offense(<<~RUBY)
+        context 'when the user does not exist' do
+          let(:user_id) { 5678 }
+                          ^^^^ Use a negative id for a record expected to be absent.
+        end
+      RUBY
+    end
+  end
+
+  it 'does not register an offense for a let-shaped call that is not a block' do
+    expect_no_offenses(<<~RUBY)
+      context 'when the user does not exist' do
+        let(:user_id, &builder)
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Flags a hardcoded positive id standing in for a record an example expects to be absent.

```ruby
# bad
context 'when the user does not exist' do
  let(:user_id) { 123 }

  it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
end

# good
let(:user_id) { -1 }
```

Auto-increment climbs across every example in a run and is not reclaimed by transactional rollback, so the counter eventually reaches the literal. A real row then occupies it, the lookup succeeds, and the example stops testing absence — passing locally, where the counter is low, and failing in CI. Auto-increment never emits a negative id.

An id only qualifies when its **own** example group expects absence (`RecordNotFound`, a `:not_found` response) or says so in its description, so a shared id in an outer group is not attributed to a nested example. The description has to name absence, not mismatch: a group saying the record belongs to someone else, or that an id is invalid, is about a row that exists.

In a list, a literal beside a real `record.id` qualifies on its own, and several literals each correct to their own negative (`-1`, `-2`) so the count the example asserts is preserved. A list only reads as record ids when every member is one — `['story', '123', '']` is a format fixture.

Not offenses: a group that builds a record carrying that id as its own attribute, a `RecordNotFound` from reloading a row the example just deleted, a literal above `MaxId` (default `100_000`), a group pinning two scalar ids (usually pinned to differ), and anything under a VCR cassette, whose recording matches on the id in the URI.

Autocorrection is `SafeAutoCorrect: false` — `-1` is right for a primary key but also changes what the example feeds to asserted messages, stubbed URIs and unsigned columns.

## Validation

Every exclusion above is a false positive found by running this against real code and fixing the offenses, first over a private Rails monorepo (292 sites, 279 fixed across 214 spec files) and then over [pirj/real-world-rspec](https://github.com/pirj/real-world-rspec).

On gitlabhq's 12,091 spec files it reports **11 offenses in 6 files**, all hand-audited as real. See [this comment](https://github.com/rubocop/rubocop-rspec_rails/pull/120#issuecomment-5465619931) for the before/after breakdown against @pirj's review.

## Relationship to rubocop/rubocop-factory_bot#192

Sibling cop, opposite direction, disjoint in practice.

|  | this cop | `FactoryBot/HardcodedId` |
|---|---|---|
| Shape | `let(:company_id) { 123 }` | `create(:company, id: 123)` |
| The id is | **read**, standing in for a row that must not exist | **written** onto a row being inserted |
| Collides with | a row the sequence hands out **later** in the run | a row that **already** occupies that key |
| Fails | silently — the example stops testing absence and still passes | at insert, or on the next lookup that finds the wrong row |
| Fix | make it negative | delete the `id:` |

Over the same gitlabhq spec tree the two flag 79 sites between them and share not one line, not even one file.
