### PR TITLE
Add new `RSpecRails/HardcodedId` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Add new `RSpecRails/HardcodedId` cop. ([@corsonknowles])
 - Speed up loading rubocop-rspec_rails by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
 - Fix offense message for `RSpecRails/HttpStatusNameConsistency` cop. ([@fatkodima])
 - Fix a false positive for `RspecRails/NegationBeValid` when use `to_not`. ([@ydah])
@@ -93,6 +94,7 @@
 [@akiomik]: https://github.com/akiomik
 [@anthony-robin]: https://github.com/anthony-robin
 [@bquorning]: https://github.com/bquorning
+[@corsonknowles]: https://github.com/corsonknowles
 [@corydiamand]: https://github.com/corydiamand
 [@eugeneius]: https://github.com/eugeneius
 [@fatkodima]: https://github.com/fatkodima

--- a/config/default.yml
+++ b/config/default.yml
@@ -12,6 +12,14 @@ RSpecRails/AvoidSetupHook:
   VersionAdded: '2.4'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/AvoidSetupHook
 
+RSpecRails/HardcodedId:
+  Description: Checks for a hardcoded `id:` passed to a persisting builder.
+  Enabled: pending
+  AllowedFactories: []
+  AllowedReceivers: []
+  VersionAdded: '2.33'
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HardcodedId
+
 RSpecRails/HaveHttpStatus:
   Description: Checks that tests use `have_http_status` instead of equality matchers.
   Enabled: pending

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -3,6 +3,7 @@
 === Department xref:cops_rspecrails.adoc[RSpecRails]
 
 * xref:cops_rspecrails.adoc#rspecrailsavoidsetuphook[RSpecRails/AvoidSetupHook]
+* xref:cops_rspecrails.adoc#rspecrailshardcodedid[RSpecRails/HardcodedId]
 * xref:cops_rspecrails.adoc#rspecrailshavehttpstatus[RSpecRails/HaveHttpStatus]
 * xref:cops_rspecrails.adoc#rspecrailshttpstatus[RSpecRails/HttpStatus]
 * xref:cops_rspecrails.adoc#rspecrailshttpstatusnameconsistency[RSpecRails/HttpStatusNameConsistency]

--- a/docs/modules/ROOT/pages/cops_rspecrails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspecrails.adoc
@@ -42,6 +42,99 @@ end
 
 * https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/AvoidSetupHook
 
+[#rspecrailshardcodedid]
+== RSpecRails/HardcodedId
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| No
+| 2.33
+| -
+|===
+
+Checks for a hardcoded `id:` passed to a persisting builder.
+
+Forcing a primary key in a spec collides with whatever else occupies
+that row -- fixtures, parallel workers, the table's auto-increment
+sequence -- and is a common source of flaky, order-dependent
+failures. Let the database assign the id and reference the returned
+record.
+
+Only `create`, `create!` and `create_list` are flagged: they insert a
+row, so a forced primary key is an outright collision risk.
+`create_list` is the worst case, forcing the identical id onto every
+record it generates. `build` and `build_stubbed` never insert, so
+they are left alone.
+
+Both `id:` and `'id' =>` are flagged: FactoryBot symbolizes override
+keys and ActiveRecord treats string and symbol attribute keys
+identically on mass-assignment, so a string-rocket key forces the
+same primary key.
+
+Only literal values are flagged. A value read from another record or
+a variable (`id: company.id`, `id: company_id`) is a reference, not a
+magic constant.
+
+[#examples-rspecrailshardcodedid]
+=== Examples
+
+[source,ruby]
+----
+# bad
+create(:company, id: 123)
+create(:company, 'id' => 123)
+create_list(:company, 3, id: 123)
+Company.create!(id: '123456789')
+
+# good - let the database assign the id
+company = create(:company)
+
+# good - a transitive record id is a reference, not a constant
+create(:employee, id: company.id)
+----
+
+[#allowedfactories_-__money__-_default_-___-rspecrailshardcodedid]
+==== AllowedFactories: ['money'] (default: [])
+
+[source,ruby]
+----
+# good - a factory that builds a value object rather than a row,
+# so `id:` is the object's own identity
+create(:money, id: 123)
+----
+
+[#allowedreceivers_-__reporting__row__-_default_-___-rspecrailshardcodedid]
+==== AllowedReceivers: ['Reporting::Row'] (default: [])
+
+[source,ruby]
+----
+# good - a constant whose `create` is not ActiveRecord's
+Reporting::Row.create(id: 123)
+----
+
+[#configurable-attributes-rspecrailshardcodedid]
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedFactories
+| `[]`
+| Array
+
+| AllowedReceivers
+| `[]`
+| Array
+|===
+
+[#references-rspecrailshardcodedid]
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec_rails/RuboCop/Cop/RSpecRails/HardcodedId
+
 [#rspecrailshavehttpstatus]
 == RSpecRails/HaveHttpStatus
 

--- a/lib/rubocop/cop/rspec_rails.rb
+++ b/lib/rubocop/cop/rspec_rails.rb
@@ -8,6 +8,7 @@ module RuboCop
       extend LazyLoader
 
       register_cop :AvoidSetupHook, "#{__dir__}/rspec_rails/avoid_setup_hook"
+      register_cop :HardcodedId, "#{__dir__}/rspec_rails/hardcoded_id"
       register_cop :HaveHttpStatus, "#{__dir__}/rspec_rails/have_http_status"
       register_cop :HttpStatus, "#{__dir__}/rspec_rails/http_status"
       register_cop :HttpStatusNameConsistency, "#{__dir__}/rspec_rails/http_status_name_consistency"

--- a/lib/rubocop/cop/rspec_rails/hardcoded_id.rb
+++ b/lib/rubocop/cop/rspec_rails/hardcoded_id.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpecRails
+      # Checks for a hardcoded `id:` passed to a persisting builder.
+      #
+      # Forcing a primary key in a spec collides with whatever else occupies
+      # that row -- fixtures, parallel workers, the table's auto-increment
+      # sequence -- and is a common source of flaky, order-dependent
+      # failures. Let the database assign the id and reference the returned
+      # record.
+      #
+      # Only `create`, `create!` and `create_list` are flagged: they insert a
+      # row, so a forced primary key is an outright collision risk.
+      # `create_list` is the worst case, forcing the identical id onto every
+      # record it generates. `build` and `build_stubbed` never insert, so
+      # they are left alone.
+      #
+      # Both `id:` and `'id' =>` are flagged: FactoryBot symbolizes override
+      # keys and ActiveRecord treats string and symbol attribute keys
+      # identically on mass-assignment, so a string-rocket key forces the
+      # same primary key.
+      #
+      # Only literal values are flagged. A value read from another record or
+      # a variable (`id: company.id`, `id: company_id`) is a reference, not a
+      # magic constant.
+      #
+      # @example
+      #   # bad
+      #   create(:company, id: 123)
+      #   create(:company, 'id' => 123)
+      #   create_list(:company, 3, id: 123)
+      #   Company.create!(id: '123456789')
+      #
+      #   # good - let the database assign the id
+      #   company = create(:company)
+      #
+      #   # good - a transitive record id is a reference, not a constant
+      #   create(:employee, id: company.id)
+      #
+      # @example AllowedFactories: ['money'] (default: [])
+      #   # good - a factory that builds a value object rather than a row,
+      #   # so `id:` is the object's own identity
+      #   create(:money, id: 123)
+      #
+      # @example AllowedReceivers: ['Reporting::Row'] (default: [])
+      #   # good - a constant whose `create` is not ActiveRecord's
+      #   Reporting::Row.create(id: 123)
+      #
+      class HardcodedId < RuboCop::Cop::Base
+        MSG = 'Do not pass a hardcoded `id:` to a persisting builder; ' \
+              'let the database assign it.'
+        RESTRICT_ON_SEND = %i[create create! create_list].freeze
+
+        def on_send(node)
+          return if allowed_receiver?(node) || allowed_factory?(node)
+
+          node.arguments.each do |argument|
+            # Every call shape (bare trailing kwargs, braced hash, positional
+            # hash) parses to a plain `hash` node.
+            next unless argument.hash_type?
+
+            argument.pairs.each do |pair|
+              add_offense(pair) if hardcoded_id?(pair)
+            end
+          end
+        end
+        alias on_csend on_send
+
+        private
+
+        def hardcoded_id?(pair)
+          key = pair.key
+          return false unless key.type?(:sym, :str)
+          return false unless key.value.to_s == 'id'
+
+          pair.value.type?(:int, :str)
+        end
+
+        # `::Foo::Bar` and `Foo::Bar` name the same constant, so compare
+        # without the leading scope operator.
+        def allowed_receiver?(node)
+          receiver = node.receiver
+          return false unless receiver
+
+          allowed_receivers.include?(receiver.source.delete_prefix('::'))
+        end
+
+        def allowed_factory?(node)
+          factory = node.first_argument
+          return false unless factory&.sym_type?
+
+          allowed_factories.include?(factory.value.to_s)
+        end
+
+        def allowed_receivers
+          @allowed_receivers ||=
+            Array(cop_config['AllowedReceivers'])
+              .to_set { |name| name.to_s.delete_prefix('::') }
+        end
+
+        def allowed_factories
+          @allowed_factories ||=
+            Array(cop_config['AllowedFactories']).to_set(&:to_s)
+        end
+      end
+    end
+  end
+end

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'cop lazy loading' do
       puts "loaded_cop_files=\#{loaded.size}"
     RUBY
 
-    expect(output).to include('registered=9', 'loaded_cop_files=0')
+    expect(output).to include('registered=10', 'loaded_cop_files=0')
   end
 
   it 'does not register a cop twice when its file is required directly' do

--- a/spec/rubocop/cop/rspec_rails/hardcoded_id_spec.rb
+++ b/spec/rubocop/cop/rspec_rails/hardcoded_id_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpecRails::HardcodedId do
+  it 'registers an offense for a hardcoded id: on a factory create' do
+    expect_offense(<<~RUBY)
+      create(:company, id: 123)
+                       ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for a hardcoded id: with no factory argument' do
+    expect_offense(<<~RUBY)
+      create(id: 123)
+             ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for id: on a create with an explicit receiver' do
+    expect_offense(<<~RUBY)
+      Company.create(id: 123)
+                     ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for id: alongside other keyword arguments' do
+    expect_offense(<<~RUBY)
+      create(:company, name: 'Acme', id: 123)
+                                     ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for id: passed via safe navigation' do
+    expect_offense(<<~RUBY)
+      model&.create(id: 123)
+                    ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for a hardcoded id: on create!' do
+    expect_offense(<<~RUBY)
+      Company.create!(id: 123)
+                      ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for a string literal id:' do
+    expect_offense(<<~RUBY)
+      create(:company, id: '123456789')
+                       ^^^^^^^^^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'registers an offense for id: on create_list' do
+    expect_offense(<<~RUBY)
+      create_list(:company, 3, id: 123)
+                               ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it "registers an offense for a string 'id' hash-rocket key" do
+    expect_offense(<<~RUBY)
+      create(:company, 'id' => 123)
+                       ^^^^^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+    RUBY
+  end
+
+  it 'does not register an offense for create without an id:' do
+    expect_no_offenses(<<~RUBY)
+      create(:company)
+    RUBY
+  end
+
+  it 'does not register an offense for other keyword arguments' do
+    expect_no_offenses(<<~RUBY)
+      create(:company, name: 'Acme')
+    RUBY
+  end
+
+  it 'does not register an offense for a nested id: on a different builder' do
+    expect_no_offenses(<<~RUBY)
+      create(:company, owner: build(:user, id: 5))
+    RUBY
+  end
+
+  it 'does not register an offense for create_list without an id:' do
+    expect_no_offenses(<<~RUBY)
+      create_list(:company, 3)
+    RUBY
+  end
+
+  it 'does not register an offense for id: on non-persisting builders' do
+    expect_no_offenses(<<~RUBY)
+      build(:company, id: 123)
+    RUBY
+  end
+
+  it 'does not register an offense for id: on build_list' do
+    expect_no_offenses(<<~RUBY)
+      build_list(:company, 3, id: 123)
+    RUBY
+  end
+
+  it 'does not register an offense for a reference id: from a local variable' do
+    expect_no_offenses(<<~RUBY)
+      create(:employee, id: company_id)
+    RUBY
+  end
+
+  it 'does not register an offense for an id read from a record' do
+    expect_no_offenses(<<~RUBY)
+      create(:employee, id: company.id)
+    RUBY
+  end
+
+  it 'does not register an offense for a non-literal hash key' do
+    expect_no_offenses(<<~RUBY)
+      create(:company, attribute => 123)
+    RUBY
+  end
+
+  it 'does not register an offense for a bare create with no arguments' do
+    expect_no_offenses(<<~RUBY)
+      create
+    RUBY
+  end
+
+  context 'with AllowedFactories' do
+    let(:cop_config) { { 'AllowedFactories' => ['money'] } }
+
+    it 'does not register an offense for an allowed factory' do
+      expect_no_offenses(<<~RUBY)
+        create(:money, :usd, id: 123)
+      RUBY
+    end
+
+    it 'still registers an offense for a factory that is not allowed' do
+      expect_offense(<<~RUBY)
+        create(:company, id: 123)
+                         ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+      RUBY
+    end
+  end
+
+  context 'with AllowedReceivers' do
+    let(:cop_config) { { 'AllowedReceivers' => ['Reporting::Row'] } }
+
+    it 'does not register an offense for an allowed receiver' do
+      expect_no_offenses(<<~RUBY)
+        Reporting::Row.create(id: 3, label: 'total')
+      RUBY
+    end
+
+    it 'does not register an offense for a leading scope operator' do
+      expect_no_offenses(<<~RUBY)
+        ::Reporting::Row.create(id: 3)
+      RUBY
+    end
+
+    it 'still registers an offense for a receiver that is not allowed' do
+      expect_offense(<<~RUBY)
+        Company.create(id: 123)
+                       ^^^^^^^ Do not pass a hardcoded `id:` to a persisting builder; let the database assign it.
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Flags a hardcoded `id:` passed to a persisting builder.

```ruby
# bad
create(:company, id: 123)
create(:company, 'id' => 123)
create_list(:company, 3, id: 123)

# good
company = create(:company)
```

Forcing a primary key in a spec collides with whatever else occupies that row — fixtures, parallel workers, the table's auto-increment sequence — and is a common source of flaky, order-dependent failures.

Only `create`, `create!` and `create_list` are flagged; `build` and `build_stubbed` never insert. `create_list` is the worst case, forcing the identical id onto every record it generates. Both `id:` and `'id' =>` count, since FactoryBot symbolizes override keys and ActiveRecord treats the two identically on mass-assignment. Literal values only — `id: company.id` is a reference.

Two config keys cover the shapes where the literal is not a database primary key: `AllowedFactories` for factories that build a value object instead of inserting a row, and `AllowedReceivers` for constants whose `create` is not ActiveRecord's.

Sibling of #120, which flags an id standing in for a record expected to be *absent*; this one flags an id forced *onto* a row being created. The two do not overlap.